### PR TITLE
package.json + template.config.js + dependency on @react-native-community/cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@react-native-community/template",
+  "version": "0.75.0",
+  "description": "The template used by `npx @react-native-community/cli init` to bootstrap a React Native application.",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "template/*"
+  ],
+  "dependencies": {},
+  "devDependencies": {},
+  "homepage": "https://github.com/react-native-community/template/tree/main",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/template.git"
+  }
+}

--- a/template.config.js
+++ b/template.config.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  placeholderName: 'HelloWorld',
+  titlePlaceholder: 'Hello App Display Name',
+  templateDir: './template',
+};

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -1,7 +1,7 @@
 # Resolve react_native_pods.rb with node to allow for hoisting
 require Pod::Executable.execute_command('node', ['-p',
   'require.resolve(
-    "react-native/scripts/react_native_pods.rb",
+     "@react-native-community/cli-platform-ios/autolinking.rb",
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
@@ -15,7 +15,7 @@ if linkage != nil
 end
 
 target 'HelloWorld' do
-  config = use_native_modules!
+  config = autolink_native_modules!
 
   use_react_native!(
     :path => config[:reactNativePath],

--- a/template/package.json
+++ b/template/package.json
@@ -21,6 +21,7 @@
     "@react-native/eslint-config": "0.74.0",
     "@react-native/metro-config": "0.74.0",
     "@react-native/typescript-config": "0.74.0",
+    "@react-native-community/cli": "latest",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",


### PR DESCRIPTION
# Background
This is part of work to remove the dependency on the `@react-native-community/cli-platform-ios/native_modules.rb` in the `react-native` package.  What we want is this:
![CleanShot 2024-03-15 at 14 38 22@2x](https://github.com/react-native-community/template/assets/49578/0339fdc6-db05-4cb6-9bb7-b013fb2456ac)

To do this, we have to split apart `native-modules.rb` into:
- `link_native_modules!` (a platform concern of injecting PodSpecs into the Xcode workplace build), and
- `list_native_modules!` (module discover is a framework concern.  For example the community template depends on [config's](https://github.com/react-native-community/cli/blob/main/docs/dependencies.md), whereas something like Expo has gone [another route](https://docs.expo.dev/workflow/configuration/))


The impact of this change means that the template now has to explicitly depend on https://npmjs.com/package/@react-native-community/cli which transitively includes both platform specific dependencies:
- https://npmjs.com/package/@react-native-community/cli-platform-ios
- https://npmjs.com/package/@react-native-community/cli-platform-android 

# Changes used
Here's the old and new dependency graph:
![dependencies](https://github.com/react-native-community/template/assets/49578/2218f4e5-79bf-45a6-8507-a1c00d024e51)



