### PR TITLE
Disable New Architecture by default for 0.75

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -32,7 +32,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=true
+newArchEnabled=false
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.


### PR DESCRIPTION
## Summary:

This mirrors the same changes we have on the `0.75-stable` release branch.
For 0.75 we intend to don't enable the New Architecture by default due to a couple of critical bugs we want to resolve first.

## Changelog:

[ANDROID] - Disable New Architecture by default for 0.75

## Test Plan:

N/A