### PR TITLE
Add nightlies/release workflow for the template

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,27 @@
+name: Nightly
+
+on:
+  workflow_dispatch:
+  # Instead of running every night we run
+  # Once for every commit in main as the traffic on this repo
+  # is lower than facebook/react-native.
+  push:
+    branches:
+      - main
+
+jobs:
+  publish_template_as_nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Setup node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 18
+      - name: Update versions to nightly
+        run: node updateTemplateVersion.js nightly
+      - name: Publish NPM as Nightly
+        run: npm publish --dry-run --tag nightly
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,8 @@ jobs:
           if [[ "$VERSION" == *"rc"* ]]; then
             npm dist-tag add @react-native-community/template@$VERSION next
           fi
-          npm dist-tag add @react-native-community/template@$VERSION $GITHUB_REF_NAME
+          if [[ "$GITHUB_REF_NAME" == *"-stable" ]]; then
+            npm dist-tag add @react-native-community/template@$VERSION $GITHUB_REF_NAME
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           VERSION="${{ inputs.version }}"
           IS_LATEST_ON_NPM="${{ inputs.is_latest_on_npm }}"
-          if [[ $IS_LATEST_ON_NPM == "true" ]]; then
+          if [[ "$IS_LATEST_ON_NPM" == "true" ]]; then
             npm dist-tag add @react-native-community/template@$VERSION latest
           fi
           if [[ "$VERSION" == *"rc"* ]]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,5 +39,6 @@ jobs:
           if [[ $VERSION == *"rc"* ]]; then
             npm dist-tag add @react-native-community/template@$VERSION next
           fi
+          npm dist-tag add @react-native-community/template@$VERSION $GITHUB_REF_NAME
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           if [[ $IS_LATEST_ON_NPM == "true" ]]; then
             npm dist-tag add @react-native-community/template@$VERSION latest
           fi
-          if [[ $VERSION == *"rc"* ]]; then
+          if [[ "$VERSION" == *"rc"* ]]; then
             npm dist-tag add @react-native-community/template@$VERSION next
           fi
           npm dist-tag add @react-native-community/template@$VERSION $GITHUB_REF_NAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version of the template we want to release. For example 0.75.0-rc.0"
+        required: true
+        type: string
+      is_latest_on_npm:
+        description: "Whether we want to tag this template release as `latest` on NPM"
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  publish_template:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Setup node.js
+        uses: actions/setup-node@v4.0.0
+        with:
+          node-version: 18
+      - name: Update versions to input one
+        run: node updateTemplateVersion.js "${{ inputs.version }}"
+      - name: Publish NPM
+        run: npm publish --dry-run --tag "${{ inputs. }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Set NPM tags
+        run: |
+          VERSION="${{ inputs.version }}"
+          IS_LATEST_ON_NPM="${{ inputs.is_latest_on_npm }}"
+          if [[ $IS_LATEST_ON_NPM == "true" ]]; then
+            npm dist-tag add @react-native-community/template@$VERSION latest
+          fi
+          if [[ $VERSION == *"rc"* ]]; then
+            npm dist-tag add @react-native-community/template@$VERSION next
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "publishConfig": {
     "access": "public"
   },
+  "type": "module",
   "files": [
     "template/*",
     "template.config.js"

--- a/package.json
+++ b/package.json
@@ -19,3 +19,4 @@
     "url": "https://github.com/react-native-community/template.git"
   }
 }
+

--- a/updateTemplateVersion.js
+++ b/updateTemplateVersion.js
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "fs";
+import { readFileSync, writeFileSync } from "fs";
 
 /**
  * Function to get the Nightly version of the package, similar to the one used in React Native.
@@ -23,35 +23,32 @@ if (!process.argv[2]) {
 const targetVersion = process.argv[2];
 
 // We first update version of the template we're about to publish.
-readFile("package.json", "utf8", (err, data) => {
-  if (err) throw err;
-  const packageJson = JSON.parse(data);
-  if (targetVersion === "nightly") {
-    packageJson.version = getNightlyVersion(packageJson.version);
-  } else {
-    packageJson.version = targetVersion;
-  }
-  const updatedData = JSON.stringify(packageJson, null, 2);
-  writeFile("package.json", updatedData, "utf8", (err) => {
-    if (err) throw err;
-    console.log(`Template version updated to ${packageJson.version}`);
-  });
-});
+const packageJsonData = readFileSync("package.json", "utf8");
+const packageJson = JSON.parse(packageJsonData);
+if (targetVersion === "nightly") {
+  packageJson.version = getNightlyVersion(packageJson.version);
+} else {
+  packageJson.version = targetVersion;
+}
+const updatedPackageJsonData = JSON.stringify(packageJson, null, 2);
+writeFileSync("package.json", updatedPackageJsonData, "utf8");
+console.log(`Template version updated to ${packageJson.version}`);
 
 // And then we update the version of the dependencies in the template.
 // To be `nightly` as well.
-readFile("template/package.json", "utf8", (err, data) => {
-  if (err) throw err;
-  const packageJson = JSON.parse(data);
-  packageJson.dependencies["react-native"] = targetVersion;
-  Object.keys(packageJson.devDependencies).forEach((key) => {
-    if (key.startsWith("@react-native")) {
-      packageJson.devDependencies[key] = targetVersion;
-    }
-  });
-  const updatedData = JSON.stringify(packageJson, null, 2);
-  writeFile("template/package.json", updatedData, "utf8", (err) => {
-    if (err) throw err;
-    console.log(`Project dependencies updated to ${targetVersion}`);
-  });
+const templatePackageJsonData = readFileSync("template/package.json", "utf8");
+const templatePackageJson = JSON.parse(templatePackageJsonData);
+templatePackageJson.dependencies["react-native"] = targetVersion;
+Object.keys(templatePackageJson.devDependencies).forEach((key) => {
+  if (key.startsWith("@react-native")) {
+    templatePackageJson.devDependencies[key] = targetVersion;
+  }
 });
+const updatedTemplatePackageJsonData = JSON.stringify(
+  templatePackageJson,
+  null,
+  2
+);
+writeFileSync("template/package.json", updatedTemplatePackageJsonData, "utf8");
+
+console.log(`Project dependencies updated to ${targetVersion}`);

--- a/updateTemplateVersion.js
+++ b/updateTemplateVersion.js
@@ -1,0 +1,57 @@
+import { readFile, writeFile } from "fs";
+
+/**
+ * Function to get the Nightly version of the package, similar to the one used in React Native.
+ * Version will look as follows:
+ * `0.75.0-nightly-20241010-abcd1234`
+ */
+function getNightlyVersion(originalVersion) {
+  const version = originalVersion.split("-")[0];
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  // Get the sha fromt he current commit on github actions
+  const sha = process.env.GITHUB_SHA.slice(0, 7);
+  return `${version}-nightly-${year}${month}${day}-${sha}`;
+}
+
+if (!process.argv[2]) {
+  console.error("Please provide a version to update the template to.");
+  process.exit(1);
+}
+const targetVersion = process.argv[2];
+
+// We first update version of the template we're about to publish.
+readFile("package.json", "utf8", (err, data) => {
+  if (err) throw err;
+  const packageJson = JSON.parse(data);
+  if (targetVersion === "nightly") {
+    packageJson.version = getNightlyVersion(packageJson.version);
+  } else {
+    packageJson.version = targetVersion;
+  }
+  const updatedData = JSON.stringify(packageJson, null, 2);
+  writeFile("package.json", updatedData, "utf8", (err) => {
+    if (err) throw err;
+    console.log(`Template version updated to ${packageJson.version}`);
+  });
+});
+
+// And then we update the version of the dependencies in the template.
+// To be `nightly` as well.
+readFile("template/package.json", "utf8", (err, data) => {
+  if (err) throw err;
+  const packageJson = JSON.parse(data);
+  packageJson.dependencies["react-native"] = targetVersion;
+  Object.keys(packageJson.devDependencies).forEach((key) => {
+    if (key.startsWith("@react-native")) {
+      packageJson.devDependencies[key] = targetVersion;
+    }
+  });
+  const updatedData = JSON.stringify(packageJson, null, 2);
+  writeFile("template/package.json", updatedData, "utf8", (err) => {
+    if (err) throw err;
+    console.log(`Project dependencies updated to ${targetVersion}`);
+  });
+});


### PR DESCRIPTION
## Summary:

This publishes a `nightly` version of the template for every new commit to main.
Moreover, it creates a workflow that allows us to publish releases from every branch as stable.

## Changelog:

[INTERNAL] - Add nightlies workflow for the template

## Test Plan:

This will currently fail till I have the `NPM_TOKEN` secret set up correctly for this to work