### PR TITLE
[GHA] Remove extra --tags from publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Update versions to input one
         run: node updateTemplateVersion.js "${{ inputs.version }}"
       - name: Publish NPM
-        run: npm publish --dry-run --tag "${{ inputs. }}"
+        run: npm publish --dry-run
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Set NPM tags


### PR DESCRIPTION
## Summary:

This parameter is unnecesary, so we can remove it as we're using `dist-tag` just below.

## Changelog:

[INTERNAL] - Remove extra --tags from publish

## Test Plan:

N/A