### PR TITLE
Remove dry-run

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,6 +22,6 @@ jobs:
       - name: Update versions to nightly
         run: node updateTemplateVersion.js nightly
       - name: Publish NPM as Nightly
-        run: npm publish --dry-run --tag nightly
+        run: npm publish --tag nightly
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Update versions to input one
         run: node updateTemplateVersion.js "${{ inputs.version }}"
       - name: Publish NPM
-        run: npm publish --dry-run
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Set NPM tags


### PR DESCRIPTION
## Summary:

Now that the token is configured, we can remove the `--dry-run` from the publishing jobs.

## Changelog:

[INTERNAL] - Remove dry-run

## Test Plan:

Will check after this PR got merged if we do have a nightly version of the template