### PR TITLE
Enable New Architecture for 0.76

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -32,7 +32,7 @@ reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
 # your application. You should enable this flag either if you want
 # to write custom TurboModules/Fabric components OR use libraries that
 # are providing them.
-newArchEnabled=false
+newArchEnabled=true
 
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.


### PR DESCRIPTION
## Summary:

This enables the New Architecture by default in 0.76 which is consistent with what we have inside React Native `main`.

## Changelog:

[ANDROID] - Enable New Architecture for 0.76