### PR TITLE
Do not update template/package.json version upon publishing

### DIFF
--- a/updateTemplateVersion.js
+++ b/updateTemplateVersion.js
@@ -33,22 +33,3 @@ if (targetVersion === "nightly") {
 const updatedPackageJsonData = JSON.stringify(packageJson, null, 2);
 writeFileSync("package.json", updatedPackageJsonData, "utf8");
 console.log(`Template version updated to ${packageJson.version}`);
-
-// And then we update the version of the dependencies in the template.
-// To be `nightly` as well.
-const templatePackageJsonData = readFileSync("template/package.json", "utf8");
-const templatePackageJson = JSON.parse(templatePackageJsonData);
-templatePackageJson.dependencies["react-native"] = targetVersion;
-Object.keys(templatePackageJson.devDependencies).forEach((key) => {
-  if (key.startsWith("@react-native")) {
-    templatePackageJson.devDependencies[key] = targetVersion;
-  }
-});
-const updatedTemplatePackageJsonData = JSON.stringify(
-  templatePackageJson,
-  null,
-  2
-);
-writeFileSync("template/package.json", updatedTemplatePackageJsonData, "utf8");
-
-console.log(`Project dependencies updated to ${targetVersion}`);


### PR DESCRIPTION
## Summary:

To be consistent with https://github.com/react-native-community/cli/pull/2417
we need to never update the versions inside `template/package.json`.

## Changelog:

[INTERNAL] - Do not update template/package.json version upon publishing