### PR TITLE
Specify `registry-url: 'https://registry.npmjs.org'` for publishing

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4.0.0
         with:
           node-version: 18
+          registry-url: 'https://registry.npmjs.org'
       - name: Update versions to nightly
         run: node updateTemplateVersion.js nightly
       - name: Publish NPM as Nightly


### PR DESCRIPTION
## Summary:

This is necessary in order for the npmjs credentials to be configured correctly