### PR TITLE
Create corresponding git tag on stable publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,17 @@ jobs:
         uses: actions/setup-node@v4.0.0
         with:
           node-version: 18
+          registry-url: 'https://registry.npmjs.org'
+      - name: Create corresponding git tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ inputs.version }}',
+              sha: context.sha
+            })
       - name: Update versions to input one
         run: node updateTemplateVersion.js "${{ inputs.version }}"
       - name: Publish NPM


### PR DESCRIPTION
## Summary:

This creates a git tag with the version name for every stable publishing.

## Changelog:

[INTERNAL] - Create corresponding git tag on stable publishing