### PR TITLE
Add padstart in nightly version

### DIFF
--- a/updateTemplateVersion.js
+++ b/updateTemplateVersion.js
@@ -9,8 +9,8 @@ function getNightlyVersion(originalVersion) {
   const version = originalVersion.split("-")[0];
   const date = new Date();
   const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
   // Get the sha fromt he current commit on github actions
   const sha = process.env.GITHUB_SHA.slice(0, 7);
   return `${version}-nightly-${year}${month}${day}-${sha}`;


### PR DESCRIPTION
## Summary:

Minor fix as I just noticed nightlies have the month with only one digit:
https://www.npmjs.com/package/@react-native-community/template?activeTab=versions

This fixes it.