### PR TITLE
fix: move updateTemplateVersion.js to commonjs + prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {},
+  "type": "commonjs",
   "files": [
     "template/*",
     "template.config.js"
@@ -15,6 +17,6 @@
   "homepage": "https://github.com/react-native-community/template/tree/main",
   "repository": {
     "type": "git",
-    "url": "https://github.com/react-native-community/template.git"
+    "url": "git+https://github.com/react-native-community/template.git"
   }
 }

--- a/scripts/lib/lib.js
+++ b/scripts/lib/lib.js
@@ -1,12 +1,12 @@
-const {execSync} = require('child_process');
+const { execSync } = require('child_process');
 
 const registry = getNpmRegistryUrl();
 
 function getNpmRegistryUrl() {
   try {
-    return execSync("npm config get registry").toString().trim();
+    return execSync('npm config get registry').toString().trim();
   } catch {
-    return "https://registry.npmjs.org/";
+    return 'https://registry.npmjs.org/';
   }
 }
 

--- a/scripts/updateTemplateVersion.js
+++ b/scripts/updateTemplateVersion.js
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "fs";
+const { readFileSync, writeFileSync } = require('fs');
 
 /**
  * Function to get the Nightly version of the package, similar to the one used in React Native.
@@ -6,7 +6,7 @@ import { readFileSync, writeFileSync } from "fs";
  * `0.75.0-nightly-20241010-abcd1234`
  */
 function getNightlyVersion(originalVersion) {
-  const version = originalVersion.split("-")[0];
+  const version = originalVersion.split('-')[0];
   const date = new Date();
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
@@ -17,19 +17,19 @@ function getNightlyVersion(originalVersion) {
 }
 
 if (!process.argv[2]) {
-  console.error("Please provide a version to update the template to.");
+  console.error('Please provide a version to update the template to.');
   process.exit(1);
 }
 const targetVersion = process.argv[2];
 
 // We first update version of the template we're about to publish.
-const packageJsonData = readFileSync("package.json", "utf8");
+const packageJsonData = readFileSync('package.json', 'utf8');
 const packageJson = JSON.parse(packageJsonData);
-if (targetVersion === "nightly") {
+if (targetVersion === 'nightly') {
   packageJson.version = getNightlyVersion(packageJson.version);
 } else {
   packageJson.version = targetVersion;
 }
 const updatedPackageJsonData = JSON.stringify(packageJson, null, 2);
-writeFileSync("package.json", updatedPackageJsonData, "utf8");
+writeFileSync('package.json', updatedPackageJsonData, 'utf8');
 console.log(`Template version updated to ${packageJson.version}`);


### PR DESCRIPTION
## Summary:
1. Somehow your change to convert this script to CommonJS got lost, updated it and ran prettier against these scripts.
2. Ran prettier against the scripts
3. You'll see the `scripts.version` of the template container package captures the version of `react-native`. It's low cost to do this now, and I anticipate it's going to be useful going forwards.

## Tests:

```shell
$ node scripts/updateTemplateVersion.js next
Template version updated to next
$ node ./scripts/updateReactNativeVersion.js nightly
Normalizing: react-native@nightly -> react-native@0.75.0-nightly-20240618-5df5ed1a8
Changing package.json dependencies:
 - react-native: 0.75.0-nightly-20240618-5df5ed1a8 → 0.75.0-nightly-20240618-5df5ed1a8
 - @react-native/babel-preset: 0.75.0-nightly-20240618-5df5ed1a8 → 0.75.0-nightly-20240618-5df5ed1a8
 - @react-native/eslint-config: 0.75.0-nightly-20240618-5df5ed1a8 → 0.75.0-nightly-20240618-5df5ed1a8
 - @react-native/metro-config: 0.75.0-nightly-20240618-5df5ed1a8 → 0.75.0-nightly-20240618-5df5ed1a8
 - @react-native/typescript-config: 0.75.0-nightly-20240618-5df5ed1a8 → 0.75.0-nightly-20240618-5df5ed1a8

Writing update template/package.json to template/package.json:

{
  "name": "HelloWorld",
  "version": "0.0.1",
  "private": true,
  "scripts": {
    "android": "react-native run-android",
    "ios": "react-native run-ios",
    "lint": "eslint .",
    "start": "react-native start",
    "test": "jest"
  },
  "dependencies": {
    "react": "19.0.0-rc-fb9a90fa48-20240614",
    "react-native": "0.75.0-nightly-20240618-5df5ed1a8"
  },
  "devDependencies": {
    "@babel/core": "^7.20.0",
    "@babel/preset-env": "^7.20.0",
    "@babel/runtime": "^7.20.0",
    "@react-native/babel-preset": "0.75.0-nightly-20240618-5df5ed1a8",
    "@react-native/eslint-config": "0.75.0-nightly-20240618-5df5ed1a8",
    "@react-native/metro-config": "0.75.0-nightly-20240618-5df5ed1a8",
    "@react-native/typescript-config": "0.75.0-nightly-20240618-5df5ed1a8",
    "@types/react": "^18.2.6",
    "@types/react-test-renderer": "^18.0.0",
    "babel-jest": "^29.6.3",
    "eslint": "^8.19.0",
    "jest": "^29.6.3",
    "prettier": "2.8.8",
    "react-test-renderer": "19.0.0-rc-fb9a90fa48-20240614",
    "typescript": "5.0.4"
  },
  "engines": {
    "node": ">=18"
  }
}

Writing update package.json to ./package.json:

{
  "name": "@react-native-community/template",
  "version": "next",
  "description": "The template used by `npx @react-native-community/cli init` to bootstrap a React Native application.",
  "license": "MIT",
  "publishConfig": {
    "access": "public"
  },
  "files": [
    "template/*",
    "template.config.js"
  ],
  "dependencies": {},
  "devDependencies": {},
  "homepage": "https://github.com/react-native-community/template/tree/main",
  "repository": {
    "type": "git",
    "url": "https://github.com/react-native-community/template.git"
  },
  "scripts": {
    "version": "0.75.0-nightly-20240618-5df5ed1a8"
  }
}
```