### PR TITLE
Revert React from 19 to 18.3.1 

### DIFF
--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -10,10 +10,8 @@ import App from '../App';
 import {it} from '@jest/globals';
 
 // Note: test renderer must be required after react-native.
-import ReactTestRenderer from 'react-test-renderer';
+import renderer from 'react-test-renderer';
 
-it('renders correctly', async () => {
-  await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />);
-  });
+it('renders correctly', () => {
+  renderer.create(<App />);
 });

--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.0.0-rc-fb9a90fa48-20240614",
+    "react": "18.3.1",
     "react-native": "0.75.0-rc.5"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.0.0-rc-fb9a90fa48-20240614",
+    "react-test-renderer": "18.3.1",
     "typescript": "5.0.4"
   },
   "engines": {


### PR DESCRIPTION
## Summary:
This diff reverts the template from using React 19 to use React 18.3.1.

## Changelog:
[General][Changed] - Revert React from 19 to  18.3.1

## Test Plan:
GHA and Release Testing