### PR TITLE
Bump compileSdk to 35

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
-        buildToolsVersion = "34.0.0"
+        buildToolsVersion = "35.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 34
+        compileSdkVersion = 35
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"
         kotlinVersion = "1.9.24"


### PR DESCRIPTION
## Summary:

This bumps compileSdk to 35 and mirrors the same change we did in facebook/react-native here:
https://github.com/facebook/react-native/commit/1333e0ee6ac78ad856b7f86234ec2606fcc48a7e

## Changelog:

[ANDROID] [CHANGED] - Bump compileSdk to 35
