### PR TITLE
Update Babel to 7.25.x

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -14,9 +14,9 @@
     "react-native": "1000.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0",
-    "@babel/preset-env": "^7.20.0",
-    "@babel/runtime": "^7.20.0",
+    "@babel/core": "^7.25.2",
+    "@babel/preset-env": "^7.25.3",
+    "@babel/runtime": "^7.25.0",
     "@react-native-community/cli": "14.0.0-alpha.11",
     "@react-native-community/cli-platform-android": "14.0.0-alpha.11",
     "@react-native-community/cli-platform-ios": "14.0.0-alpha.11",


### PR DESCRIPTION
## Summary:

This updates babel to 7.25.x, mirroring the change we landed in react-native here:
https://github.com/facebook/react-native/commit/b37101486bd4dc26f6ec4e646e12d1484ec9479f

## Changelog:

[GENERAL] [CHANGED] - Update Babel to 7.25.x
