### PR TITLE
Downbump Gradle to 8.10.0

### DIFF
--- a/template/android/gradle/wrapper/gradle-wrapper.properties
+++ b/template/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary:

See https://github.com/gradle/gradle/issues/30472 for more context on why we're doing this.

## Changelog:

[ANDROID] [CHANGED] - Downbump Gradle to 8.10.0
