### PR TITLE
fix: Add privacyInfo reference for new projects to prevent PrivacyInfo being added twice

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		7699B88040F8A987B510C191 /* libPods-HelloWorld-HelloWorldTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 19F6CBCC0A4E27FBF8BF4A61 /* libPods-HelloWorld-HelloWorldTests.a */; };
+		161DCD825E7E4221D664DD8A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
@@ -245,6 +246,7 @@
 			files = (
 				81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */,
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				161DCD825E7E4221D664DD8A /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary:

This PR fixes an issue with PrivacyInfo files. 

When generating a new project for using the latest RC 0.76.0.rc0 I got two privacy manifests references in Xcode. 

This is because `PrivacyManifestUtils` look for build phase reference: 

```ruby
reference_exists = target.resources_build_phase.files_references.any? { |file_ref| file_ref&.path&.end_with? "xcprivacy" }
```

Which doesn't exist for the generated template. 

Here is how Xcode file tree looks like after installing pods: 

![CleanShot 2024-09-12 at 13 23 21@2x](https://github.com/user-attachments/assets/44e5bb55-a1ab-4b4b-bfe4-e4a6808afd15)

We can also fix this inside of `PrivacyManifestUtils` utility but Im not sure which one is better. 

When you create this file in Xcode its added to the `PBXBuildFile section` so the utility works good for existing projects, this issue only appears in newly generated projects.

## Changelog:

[IOS] [FIXED] - Don't add PrivacyInfo to Xcode references twice

## Test Plan:

1. Generate a new project
2. Execute pod install
3. Check if only one PrivacyInfo file exists
