### PR TITLE
Remove babel-jest dependency

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -26,7 +26,6 @@
     "@react-native/typescript-config": "0.76.0-main",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
-    "babel-jest": "^29.6.3",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

> [!Note]
> Depends on https://github.com/facebook/react-native/pull/46462.

Now included with `react-native` since https://github.com/facebook/react-native/pull/46462.

## Changelog:

[General][Removed] - Remove `babel-jest` dependency

## Test Plan:

—
