### PR TITLE
Update .gitignore to ignore project + template dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
+# Dependencies
+/node_modules
 
+# Cache and log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Files in template directory (when manually testing)
+/template/node_modules
+/template/yarn.lock


### PR DESCRIPTION
## Summary

`.gitignore` was empty, should cover `/node_modules` for the project. Additionally, ignore installed deps within `template/` (useful during manual testing).

Changelog: [Internal]

## Test Plan

—
