### PR TITLE
Add @types/jest and simplify test example

### DIFF
--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -2,17 +2,11 @@
  * @format
  */
 
-import 'react-native';
 import React from 'react';
+import ReactTestRenderer from 'react-test-renderer';
 import App from '../App';
 
-// Note: import explicitly to use the types shipped with jest.
-import {it} from '@jest/globals';
-
-// Note: test renderer must be required after react-native.
-import ReactTestRenderer from 'react-test-renderer';
-
-it('renders correctly', async () => {
+test('renders correctly', async () => {
   await ReactTestRenderer.act(() => {
     ReactTestRenderer.create(<App />);
   });

--- a/template/package.json
+++ b/template/package.json
@@ -24,6 +24,7 @@
     "@react-native/eslint-config": "0.77.0-main",
     "@react-native/metro-config": "0.77.0-main",
     "@react-native/typescript-config": "0.77.0-main",
+    "@types/jest": "^29.5.13",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "eslint": "^8.19.0",


### PR DESCRIPTION
## Summary

This is now simpler, and more closely aligned with Expo's template. Also switch `it()` to `test()`.

Changelog:
[General][Added] - Add `@types/jest` dev dependency, simplify test example

## Test Plan

Apply changes to a freshly created `0.76.0-rc.2` project.

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/f7864bd8-2949-495e-b3ee-3c515d11a606">

✅ `@types/jest` automatically discovered by TypeScript, allowing us to remove the old type import
✅ Tests pass