### PR TITLE
Update release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,10 @@ jobs:
           fi
           "${GIT[@]}" config --global user.name 'React Native Bot'
           "${GIT[@]}" config --global user.email 'bot@reactnative.dev'
+          if [ -z "$("${GIT[@]}" status --porcelain)" ]; then
+            echo "No changes, a previous release might have failed at the publish step. Continue to retry."
+            exit 0
+          fi
           "${GIT[@]}" commit -am "Bumping template to $VERSION"
           "${GIT[@]}" push
           "${GIT[@]}" tag $VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,4 +69,4 @@ jobs:
             npm publish --tag "$GITHUB_REF_NAME" "${args[@]}"
           else
             npm publish "${args[@]}"
-          if
+          fi


### PR DESCRIPTION
## Summary:

1. Fixed a typo in the shell script
2. Allow the release release workflow to continue if there are no git changes. This can occur if the `npm publish` step fails.  Npm isn't going to let us publish duplicates, so it's safe to try again.

## Testing

0.75.4 ran into these issues, this has already been picked onto 0.75-stable and 0.76-stable.