### PR TITLE
Bump Kotlin 1.9.x to 2.0.x

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 34
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "1.9.24"
+        kotlinVersion = "2.0.21"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary:

This bumps Kotlin from 1.9.x to 2.0.x

There are no API breaking changes for users.
It's set to ship in React Native 0.77

## Changelog:

[ANDROID] [CHANGED] - Bump Kotlin 1.9.x to 2.0.x
