### PR TITLE
Pin `xcodeproj` gem to `< 1.26.0`

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -6,3 +6,4 @@ ruby ">= 2.6.10"
 # Exclude problematic versions of cocoapods and activesupport that causes build failures.
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
+gem 'xcodeproj', '< 1.26.0'


### PR DESCRIPTION
## Summary:

The Xcodeproj gem has been released yesterday to version 1.26.0 and it broke the CI pipeline of react native.

This should fix the issue

## Changelog
[Internal] - Pin Xcodeproj gem to 1.26.0

## Test Plan:

GHA
