### PR TITLE
fix: handle response from npm when one version

### DIFF
--- a/scripts/bumpedTemplateVersion.sh
+++ b/scripts/bumpedTemplateVersion.sh
@@ -41,7 +41,7 @@ if [[ $1 =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
     exit 0;
   fi
   # Bump PATCH
-  PUBLISHED=$(jq -r 'last | .version' <<< $CURRENT_VERSION | awk -F'.' '{ print $1"."$2"."($3+1) }')
+  PUBLISHED=$(jq -r 'if . | type == "array" then last | .version else .version end' <<< $CURRENT_VERSION | awk -F'.' '{ print $1"."$2"."($3+1) }')
   echo $PUBLISHED;
   exit 0
 fi


### PR DESCRIPTION
We hit a case with 0.76.0, where there is a single published version, `npm show --json` returns `{...}` instead of `[{...}, {...}, ...]`.

This handles both cases.  Took an age to figure out a good testing strategy.