### PR TITLE
feat: use react-native-safe-area-context

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import type {PropsWithChildren} from 'react';
 import {
-  SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -17,6 +16,7 @@ import {
   View,
 } from 'react-native';
 
+import {SafeAreaProvider, SafeAreaView} from 'react-native-safe-area-context'
 import {
   Colors,
   DebugInstructions,
@@ -63,36 +63,38 @@ function App(): React.JSX.Element {
   };
 
   return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar
-        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-        backgroundColor={backgroundStyle.backgroundColor}
-      />
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={backgroundStyle}>
-        <Header />
-        <View
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-          }}>
-          <Section title="Step One">
-            Edit <Text style={styles.highlight}>App.tsx</Text> to change this
-            screen and then come back to see your edits.
-          </Section>
-          <Section title="See Your Changes">
-            <ReloadInstructions />
-          </Section>
-          <Section title="Debug">
-            <DebugInstructions />
-          </Section>
-          <Section title="Learn More">
-            Read the docs to discover what to do next:
-          </Section>
-          <LearnMoreLinks />
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <SafeAreaView style={backgroundStyle}>
+        <StatusBar
+          barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+          backgroundColor={backgroundStyle.backgroundColor}
+        />
+        <ScrollView
+          contentInsetAdjustmentBehavior="automatic"
+          style={backgroundStyle}>
+          <Header />
+          <View
+            style={{
+              backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            }}>
+            <Section title="Step One">
+              Edit <Text style={styles.highlight}>App.tsx</Text> to change this
+              screen and then come back to see your edits.
+            </Section>
+            <Section title="See Your Changes">
+              <ReloadInstructions />
+            </Section>
+            <Section title="Debug">
+              <DebugInstructions />
+            </Section>
+            <Section title="Learn More">
+              Read the docs to discover what to do next:
+            </Section>
+            <LearnMoreLinks />
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 }
 

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "19.0.0-rc-fb9a90fa48-20240614",
-    "react-native": "1000.0.0"
+    "react-native": "1000.0.0",
+    "react-native-safe-area-context": "^4.14.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
We're recommending using [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) instead of [SafeAreaView](https://reactnative.dev/docs/safeareaview) for Android 15 `targetSDK = 35`.

| With StatusBar | Without StatusBar |
| --------------- | ------------------ |
| ![e2e](https://github.com/user-attachments/assets/e17c2df3-4ee5-48dd-8371-d0444556ebcc) | ![e2e-hidden-status-bar](https://github.com/user-attachments/assets/9f7af6a8-9c73-4b6b-9b4a-b03deacf369b) |