### PR TITLE
Revert React 19RC to 18.3.1

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.0.0-rc-fb9a90fa48-20240614",
+    "react": "18.3.1",
     "react-native": "1000.0.0"
   },
   "devDependencies": {
@@ -30,7 +30,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.0.0-rc-fb9a90fa48-20240614",
+    "react-test-renderer": "18.3.1",
     "typescript": "5.0.4"
   },
   "engines": {


### PR DESCRIPTION
## Summary:
Commit https://github.com/facebook/react-native/commit/7e268c9d52c99ed5af7b57158bcf9bdaeea68d11 reverted React 19 on main, but now the creation of a new app fails on npm install due to a mismatch in react versions. 
This should fix them

## Changelog:
[General][Changed] - Revert React to 18.3.1 

## Test Plan:
N/A