### PR TITLE
fix(bumpTemplateVersion) test missing the stub for npm

### DIFF
--- a/scripts/__tests__/stub/npm
+++ b/scripts/__tests__/stub/npm
@@ -1,0 +1,2 @@
+#!/bin/bash
+cat $NPM_STUB_FIFO


### PR DESCRIPTION
This is needed by the `bumpTemplateVersion` script test.  We're not running these tests on PRs, only locally (so it hasn't been flagged).