### PR TITLE
[iOS] Pass the RCTAppDependencyProvider to the RCTAppDelegate

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.swift
+++ b/template/ios/HelloWorld/AppDelegate.swift
@@ -1,23 +1,25 @@
 import UIKit
 import React
 import React_RCTAppDelegate
+import ReactCodegen
 
 @main
 class AppDelegate: RCTAppDelegate {
   override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
     self.moduleName = "HelloWorld"
-    
+    self.dependencyProvider = RCTAppDependencyProvider()
+
     // You can add your custom initial props in the dictionary below.
     // They will be passed down to the ViewController used by React Native.
     self.initialProps = [:]
-    
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
-  
+
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()
   }
-  
+
   override func bundleURL() -> URL? {
 #if DEBUG
     RCTBundleURLProvider.sharedSettings().jsBundleURL(forBundleRoot: "index")


### PR DESCRIPTION
## Summary:

We recently inverted the dependency between `ReactCodegen` and `React-RCTAppDelegate`, so that now the Codegen depends on the AppDelegate.

Remember that `ReactCodegen` is generated when the user run `pod install`, while the RCTAppDelegate exists in React Native, so the new dependency is more correct and enables prebuilds for iOS.

For that reason, we need to make sure that the App passes to React Native the dependency provider before React Native is started.

## Changelog:
[iOS][Breaking] - Pass the dependency provider from the App to React Native.

## Test Plan:
Tested locally in a nightly.