### PR TITLE
Apply 'react-native-safe-area-context' to support Android 15 forced edge-to-edge

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import type {PropsWithChildren} from 'react';
 import {
-  SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -24,6 +23,7 @@ import {
   LearnMoreLinks,
   ReloadInstructions,
 } from 'react-native/Libraries/NewAppScreen';
+import {SafeAreaProvider, SafeAreaView, useSafeAreaInsets} from 'react-native-safe-area-context';
 
 type SectionProps = PropsWithChildren<{
   title: string;
@@ -56,43 +56,56 @@ function Section({children, title}: SectionProps): React.JSX.Element {
 }
 
 function App(): React.JSX.Element {
+  return (
+    <SafeAreaProvider>
+      <MainContent />
+    </SafeAreaProvider>
+  );
+}
+
+function MainContent(): React.JSX.Element {
+  const insets = useSafeAreaInsets();
+
   const isDarkMode = useColorScheme() === 'dark';
 
   const backgroundStyle = {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
+    bottomPadding: insets.bottom,
   };
 
+  const contentContainerStyle = { paddingBottom: insets.bottom };
+
   return (
-    <SafeAreaView style={backgroundStyle}>
-      <StatusBar
-        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-        backgroundColor={backgroundStyle.backgroundColor}
-      />
-      <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
-        style={backgroundStyle}>
-        <Header />
-        <View
-          style={{
-            backgroundColor: isDarkMode ? Colors.black : Colors.white,
-          }}>
-          <Section title="Step One">
-            Edit <Text style={styles.highlight}>App.tsx</Text> to change this
-            screen and then come back to see your edits.
-          </Section>
-          <Section title="See Your Changes">
-            <ReloadInstructions />
-          </Section>
-          <Section title="Debug">
-            <DebugInstructions />
-          </Section>
-          <Section title="Learn More">
-            Read the docs to discover what to do next:
-          </Section>
-          <LearnMoreLinks />
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+    <View style={backgroundStyle}>
+        <StatusBar
+          barStyle={isDarkMode ? 'light-content' : 'dark-content'}
+          backgroundColor={backgroundStyle.backgroundColor}
+        />
+        <ScrollView
+          contentContainerStyle={contentContainerStyle}
+          style={backgroundStyle}>
+          <Header badgeTopMargin={insets.top}/>
+          <View
+            style={{
+              backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            }}>
+            <Section title="Step One">
+              Edit <Text style={styles.highlight}>App.tsx</Text> to change this
+              screen and then come back to see your edits.
+            </Section>
+            <Section title="See Your Changes">
+              <ReloadInstructions />
+            </Section>
+            <Section title="Debug">
+              <DebugInstructions />
+            </Section>
+            <Section title="Learn More">
+              Read the docs to discover what to do next:
+            </Section>
+            <LearnMoreLinks />
+          </View>
+        </ScrollView>
+      </View>
   );
 }
 

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "18.3.1",
-    "react-native": "1000.0.0"
+    "react-native": "1000.0.0",
+    "react-native-safe-area-context": "^4.14.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary:

### Why:
[`<SafeAreaView/>`](https://reactnative.dev/docs/next/safeareaview) is iOS only.  This becomes an issue for Android 15, where [edge-to-edge is mandatory](https://developer.android.com/develop/ui/views/layout/edge-to-edge).  We should be guiding users how to write good apps to handle this.

### How:
This change updates the template to show our current recommended pattern for writing apps that are aware of the safe area to layout components.


## Changes:
- Added [react-native-safe-area-context](https://github.com/th3rdwave/react-native-safe-area-context) to handle forced ege-to-edge on Android 15
- Updating Android targetSdk to 35

-  **Very important note**: This PR requires updated to the Header component (PR [here](https://github.com/facebook/react-native/pull/47708)) under the `Libraries/NewAppScreen` for it to work, which will have to go out in a release.  This change can't land in a `-stable` branch until that commit is picked for a branch. 


## Changelog:

[GENERAL] [ADDED] - Added `react-native-safe-area-context` to handle forced ege-to-edge on Android 15
[ANDROID] [CHANGED] - Updating Android TargetSdk to 35

## Test Plan:

Applied same code to new app created with template, and have captured screenshots:

| A | B |
| -- | -- |
| <video src="https://github.com/user-attachments/assets/53aeb3c6-d838-4a3e-a6a6-0d809b7dae10" /> | <video src="https://github.com/user-attachments/assets/84f1510c-e171-468c-8d47-a453ce8b527f" /> |
| <video src="https://github.com/user-attachments/assets/fd475eed-30cb-418b-b9c3-edff1a27e88a" /> | <video src="https://github.com/user-attachments/assets/d73b4977-e1d1-403c-8c82-3f592f46379c" /> |

