### PR TITLE
remove SafeAreaView which has no effect on the UI

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import type {PropsWithChildren} from 'react';
 import {
-  SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -63,7 +62,7 @@ function App(): React.JSX.Element {
   };
 
   return (
-    <SafeAreaView style={backgroundStyle}>
+    <View style={backgroundStyle}>
       <StatusBar
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         backgroundColor={backgroundStyle.backgroundColor}
@@ -92,7 +91,7 @@ function App(): React.JSX.Element {
           <LearnMoreLinks />
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
## Summary:

- removing SafeAreaView has no effect on the UI
- It is also iOS only and not recommended moving forward so removing it
- **Important Note:** This PR can only be merged after new version of RN is released with changes here: https://github.com/facebook/react-native/pull/47734

## Changelog:

[GENERAL][REMOVED] - Removed SafeAreaView usage in template app

## Test Plan:

Manually editing generated template app.

**iOS with SafeAreaView:**

https://github.com/user-attachments/assets/0cf4aeb1-598a-4d10-b8cd-0cbb8a689fa3

**iOS without SafeAreaView:**

https://github.com/user-attachments/assets/2b53afa8-cfed-428b-aecf-127a8b5de406

They look the same with or without the SafeAreaView.

------
**Note:** It was not handled in the PR but leaving a note as future reference. Safe area seems to be handled in `ScrollView` with `contentInsetAdjustmentBehavior="automatic"` prop (code [here](https://github.com/react-native-community/template/blob/6d3ccca9d0095b1c8e24554ec1675f2f0098062e/template/App.tsx#L72)). Removing this on iOS looks like this:


https://github.com/user-attachments/assets/803f8410-bcbe-4760-a8b4-49cf1a309bcb



