### PR TITLE
Use the ReactAppDependencyProvider in the template

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.swift
+++ b/template/ios/HelloWorld/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import React
 import React_RCTAppDelegate
-import ReactCodegen
+import ReactAppDependencyProvider
 
 @main
 class AppDelegate: RCTAppDelegate {


### PR DESCRIPTION
## Summary

This change depends on https://github.com/facebook/react-native/pull/47761.

It uses the new pod, which is compatible with swift, to inject the AppDependency in React Native

## Changelog
[iOS][Breaking] - Use the new ReactAppDependencyProvider pod in AppDelegate

## Test Plan:
Tested with a nightly app with an external dependency, with both static libraries and dynamic frameworks