### PR TITLE
Gradle to 8.11.1

### DIFF
--- a/template/android/gradle/wrapper/gradle-wrapper.properties
+++ b/template/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary:

This bumps Gradle to the latest stable.
Ideally should mitigate:
- https://github.com/facebook/react-native/issues/46210

## Changelog:

[ANDROID] [CHANGED] - Gradle to 8.11.1

## Test Plan:

N/A
