### PR TITLE
Android targetSdk 35 update - Add Android only padding to account for lack of SafeAreaView

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import type {PropsWithChildren} from 'react';
 import {
+  Platform,
   SafeAreaView,
   ScrollView,
   StatusBar,
@@ -62,6 +63,9 @@ function App(): React.JSX.Element {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
 
+  // Note: adding hacky padding to avoid importing rn-safe-area-context library but should not be done in production
+  const hackyPadding = Platform.OS === 'android' ? '5%' : 0;
+
   return (
     <SafeAreaView style={backgroundStyle}>
       <StatusBar
@@ -71,10 +75,14 @@ function App(): React.JSX.Element {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         style={backgroundStyle}>
-        <Header />
+        <View style={{paddingRight: hackyPadding}}>
+          <Header/>
+        </View>
         <View
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            paddingHorizontal: hackyPadding,
+            paddingBottom: hackyPadding,
           }}>
           <Section title="Step One">
             Edit <Text style={styles.highlight}>App.tsx</Text> to change this

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Updating to targetSdk 35 on Android enforces edge-to-edge on Android 15+.
We decided not to use `react-native-safe-area-context` in the template (PR #84 ) to reduce external dependency although it is the [current recommendation handling forced edge-to-edge](https://github.com/react-native-community/discussions-and-proposals/discussions/827).
To account for UI overlap, we are using a magic padding value for Android in the template.
iOS still uses SafeAreaView and remain unaffected.

## Changelog:

[ANDROID][CHANGED] - update targetSdk to 35 which will enforce edge-to-edge on Android 15+

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

https://github.com/user-attachments/assets/be66f016-8dc5-4e68-bffb-20bc70956efc

https://github.com/user-attachments/assets/6dad7c4b-8694-4b33-ab05-a85e2d51211d


https://github.com/user-attachments/assets/51f74828-b82a-4751-bb0b-d20ade2bee1c

https://github.com/user-attachments/assets/4fa59eb5-798c-4b99-87eb-9d5754860682




<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
