### PR TITLE
Android targetSdk 35 update - remove SafeAreaView and use padding

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -8,7 +8,6 @@
 import React from 'react';
 import type {PropsWithChildren} from 'react';
 import {
-  SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
@@ -62,19 +61,25 @@ function App(): React.JSX.Element {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
 
+  // Note: adding hacky padding to avoid importing rn-safe-area-context library but should not be done in production
+  const hackyPadding = '5%';
+
   return (
-    <SafeAreaView style={backgroundStyle}>
+    <View style={backgroundStyle}>
       <StatusBar
         barStyle={isDarkMode ? 'light-content' : 'dark-content'}
         backgroundColor={backgroundStyle.backgroundColor}
       />
       <ScrollView
-        contentInsetAdjustmentBehavior="automatic"
         style={backgroundStyle}>
-        <Header />
+        <View style={{paddingRight: hackyPadding}}>
+          <Header/>
+        </View>
         <View
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
+            paddingHorizontal: hackyPadding,
+            paddingBottom: hackyPadding,
           }}>
           <Section title="Step One">
             Edit <Text style={styles.highlight}>App.tsx</Text> to change this
@@ -92,7 +97,7 @@ function App(): React.JSX.Element {
           <LearnMoreLinks />
         </View>
       </ScrollView>
-    </SafeAreaView>
+    </View>
   );
 }
 

--- a/template/App.tsx
+++ b/template/App.tsx
@@ -62,7 +62,7 @@ function App(): React.JSX.Element {
   };
 
   /*
-   * To keep the template simple and small we're adding padding to prevent view 
+   * To keep the template simple and small we're adding padding to prevent view
    * from rendering under the System UI.
    * For bigger apps the reccomendation is to use `react-native-safe-area-context`:
    * https://github.com/AppAndFlow/react-native-safe-area-context
@@ -80,14 +80,14 @@ function App(): React.JSX.Element {
       />
       <ScrollView
         style={backgroundStyle}>
-        <View style={{paddingRight: hackyPadding}}>
+        <View style={{paddingRight: safePadding}}>
           <Header/>
         </View>
         <View
           style={{
             backgroundColor: isDarkMode ? Colors.black : Colors.white,
-            paddingHorizontal: hackyPadding,
-            paddingBottom: hackyPadding,
+            paddingHorizontal: safePadding,
+            paddingBottom: safePadding,
           }}>
           <Section title="Step One">
             Edit <Text style={styles.highlight}>App.tsx</Text> to change this

--- a/template/App.tsx
+++ b/template/App.tsx
@@ -61,8 +61,16 @@ function App(): React.JSX.Element {
     backgroundColor: isDarkMode ? Colors.darker : Colors.lighter,
   };
 
-  // Note: adding hacky padding to avoid importing rn-safe-area-context library but should not be done in production
-  const hackyPadding = '5%';
+  /*
+   * To keep the template simple and small we're adding padding to prevent view 
+   * from rendering under the System UI.
+   * For bigger apps the reccomendation is to use `react-native-safe-area-context`:
+   * https://github.com/AppAndFlow/react-native-safe-area-context
+   *
+   * You can read more about it here:
+   * https://github.com/react-native-community/discussions-and-proposals/discussions/827
+   */
+  const safePadding = '5%';
 
   return (
     <View style={backgroundStyle}>

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
         compileSdkVersion = 35
-        targetSdkVersion = 34
+        targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

**This is an alternative implementation for PR #94 which removes SafeAreaView entirely and uses magic padding for both iOS and Android.**

Updating to targetSdk 35 on Android enforces edge-to-edge on Android 15+.
We decided not to use react-native-safe-area-context in the template (PR https://github.com/react-native-community/template/pull/84 ) to reduce external dependency although it is the [recommendation](https://github.com/react-native-community/discussions-and-proposals/discussions/827).
To account for UI overlap, we are using a magic padding value for both iOS and Android in the template.
Also SafeAreaView (iOS only) was removed so same code is used on both platforms.

## Changelog:
[ANDROID][CHANGED] - update targetSdk to 35 which will enforce edge-to-edge on Android 15+
[GENERAL][REMOVED] - Removed use of SafeAreaView
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

https://github.com/user-attachments/assets/866f05be-6653-4255-8c54-51f166b43054


https://github.com/user-attachments/assets/f13342b3-0e77-4cb1-aed1-a1a67630588d


https://github.com/user-attachments/assets/9a81d115-fa58-47b5-9d11-1a6a0f7a004b

https://github.com/user-attachments/assets/281b5e3c-8dc2-4ff6-8e6e-927ccfddbc38



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
