### PR TITLE
Add .kotlin/ to gitignore

### DIFF
--- a/template/_gitignore
+++ b/template/_gitignore
@@ -33,6 +33,7 @@ local.properties
 .cxx/
 *.keystore
 !debug.keystore
+.kotlin/
 
 # node.js
 #


### PR DESCRIPTION
## Summary:

This is needed as K2 (from Kotlin 2.0) might start to add files to the .kotlin folder.

