### PR TITLE
Move JSC to be consumed from Maven Central

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -63,14 +63,14 @@ def enableProguardInReleaseBuilds = false
  * The preferred build flavor of JavaScriptCore (JSC)
  *
  * For example, to use the international variant, you can use:
- * `def jscFlavor = 'org.webkit:android-jsc-intl:+'`
+ * `def jscFlavor = io.github.react-native-community:jsc-android-intl:2026004.+`
  *
  * The international variant includes ICU i18n library and necessary data
  * allowing to use e.g. `Date.toLocaleString` and `String.localeCompare` that
  * give correct results when using with locales other than en-US. Note that
  * this variant is about 6MiB larger per architecture than default.
  */
-def jscFlavor = 'org.webkit:android-jsc:+'
+def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
 android {
     ndkVersion rootProject.ext.ndkVersion


### PR DESCRIPTION
## Summary:

This is a follow-up to:
- https://github.com/facebook/react-native/pull/47972

We need to use the correct updated coordinates for JSC as otherwise we won't be able to fetch it correctly in 0.78.

