### PR TITLE
Pin concurrent-ruby to fix e2e tests

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -7,3 +7,4 @@ ruby ">= 2.6.10"
 gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
+gem 'concurrent-ruby', '< 1.3.4'


### PR DESCRIPTION
## Summary:

Concurrent-ruby shipped a new version tonight which is broken. Pinning it to the right one.

## Changelog:
[iOS][Changed] - Pinning concurrent-ruby to fix cocoapods

## Test Plan:
GHA