### PR TITLE
feat: migrate example tests to @testing-library/react-native

### DIFF
--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -3,11 +3,10 @@
  */
 
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import { render, screen } from '@testing-library/react-native';
 import App from '../App';
 
-test('renders correctly', async () => {
-  await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />);
-  });
+test('renders correctly', () => {
+  render(<App />);
+  expect(screen.getByText('Welcome to React Native')).toBeOnTheScreen();
 });

--- a/template/package.json
+++ b/template/package.json
@@ -24,6 +24,7 @@
     "@react-native/eslint-config": "0.78.0-main",
     "@react-native/metro-config": "0.78.0-main",
     "@react-native/typescript-config": "0.78.0-main",
+    "@testing-library/react-native": "^13.0.1",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.0.0",
     "@types/react-test-renderer": "^19.0.0",


### PR DESCRIPTION
## Summary:

As React Test Renderer is now [deprecated](https://react.dev/warnings/react-test-renderer), it make sense to switch example test from RTR to React Native Testing Library which is recommended for RN env.

While RNTL currently uses RTR under the hood, there are works in progress to replace internal RTR usage with alternative supported test renderer. Migrating tests now, direct users to future-proof testing solution.

Replaces #77 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

GENERAL CHANGED - Migrate example test from deprecated React Test Renderer to React Native Testing Library (@testing-library/react-native).

## Test Plan:

Run tests included in the `template` directory.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
