### PR TITLE
[0.76] Bump Kotlin to 1.9.25 inside template

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 34
         ndkVersion = "26.1.10909125"
-        kotlinVersion = "1.9.24"
+        kotlinVersion = "1.9.25"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary:

This is needed to potentially mitigate:
- https://github.com/facebook/react-native/issues/49115

We also need to ship this alongside this pick:
- https://github.com/facebook/react-native/pull/49135

## Changelog:

[ANDROID] [CHANGED] - Bump Kotlin to 1.9.25
