### PR TITLE
fix: make React native compatible with Ruby 3.4

### DIFF
--- a/template/Gemfile
+++ b/template/Gemfile
@@ -8,3 +8,9 @@ gem 'cocoapods', '>= 1.13', '!= 1.15.0', '!= 1.15.1'
 gem 'activesupport', '>= 6.1.7.5', '!= 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
 gem 'concurrent-ruby', '< 1.3.4'
+
+# Ruby 3.4.0 has removed some libraries from the standard library.
+gem 'bigdecimal'
+gem 'logger'
+gem 'benchmark'
+gem 'mutex_m'


### PR DESCRIPTION
## Summary:

This PR is a follow-up after https://github.com/facebook/react-native/pull/49293 it makes React Native compatible with Ruby 3.4 which removed some gems from the standard library. 

## Changelog:

[IOS] [ADDED] - make React native compatible with Ruby 3.4


## Test Plan:

N/A