### PR TITLE
fix: `@react-native/community-cli-plugin` depends on `@react-native-community/cli-server-api`

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -20,6 +20,7 @@
     "@react-native-community/cli": "15.0.1",
     "@react-native-community/cli-platform-android": "15.0.1",
     "@react-native-community/cli-platform-ios": "15.0.1",
+    "@react-native-community/cli-server-api": "15.0.1",
     "@react-native/babel-preset": "0.78.0-main",
     "@react-native/eslint-config": "0.78.0-main",
     "@react-native/metro-config": "0.78.0-main",


### PR DESCRIPTION
## Summary:

See https://github.com/facebook/react-native/issues/47309 for context.

## Changelog:

[GENERAL] [FIXED] - `@react-native/community-cli-plugin` requires `@react-native-community/cli-server-api` to register the `bundle` and `start` commands correctly.

## Test Plan:

n/a