### PR TITLE
feat: migrate off RCTAppDelegate

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.swift
+++ b/template/ios/HelloWorld/AppDelegate.swift
@@ -4,18 +4,36 @@ import React_RCTAppDelegate
 import ReactAppDependencyProvider
 
 @main
-class AppDelegate: RCTAppDelegate {
-  override func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-    self.moduleName = "HelloWorld"
-    self.dependencyProvider = RCTAppDependencyProvider()
+class AppDelegate: UIResponder, UIApplicationDelegate {
+  var window: UIWindow?
 
-    // You can add your custom initial props in the dictionary below.
-    // They will be passed down to the ViewController used by React Native.
-    self.initialProps = [:]
+  var reactNativeDelegate: ReactNativeDelegate?
+  var reactNativeFactory: RCTReactNativeFactory?
 
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+  ) -> Bool {
+    let delegate = ReactNativeDelegate()
+    let factory = RCTReactNativeFactory(delegate: delegate)
+    delegate.dependencyProvider = RCTAppDependencyProvider()
+
+    reactNativeDelegate = delegate
+    reactNativeFactory = factory
+
+    window = UIWindow(frame: UIScreen.main.bounds)
+
+    factory.startReactNative(
+      withModuleName: "HelloWorld",
+      in: window,
+      launchOptions: launchOptions
+    )
+
+    return true
   }
+}
 
+class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()
   }


### PR DESCRIPTION
## Summary:

Following the work done in core: https://github.com/facebook/react-native/pull/49078 which deprecated RCTAppDelegate we migrate off of it. 

### Why?

`RCTAppDelegate` introduced a strong coupling between React Native and AppDelegate pattern. From iOS 13+ there is a newer equivalent (Scene Delegate) which is not possible to achieve with the current architecture. The proposed solution involves migration to an `RCTReactNativeFactory` a class that encapsulates the initialization logic of React Native. 

This migration will make brownfield initialization easier by making it more flexible and simpler to integrate into already established apps. 

## Changelog:

[IOS] [CHANGED] - Migrate off RCTAppDelegate

## Test Plan:

CI Green
