### PR TITLE
Add rn-build-version to default template for auto upgrade version

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -7,7 +7,15 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "build:android:apk": "rn-build-version && cd android && ./gradlew clean assembleRelease",
+    "build:android:aab": "rn-build-version && cd android && ./gradlew clean bundleRelease",
+    "build:android:apk:fast": "rn-build-version && cd android && ./gradlew assembleRelease",
+    "build:android:aab:fast": "rn-build-version && cd android && ./gradlew bundleRelease",
+    "build:android:apk:local": "cd android && ./gradlew clean assembleRelease",
+    "build:android:aab:local": "cd android && ./gradlew clean bundleRelease",
+    "build:android:apk:local:fast": "cd android && ./gradlew assembleRelease",
+    "build:android:aab:local:fast": "cd android && ./gradlew bundleRelease"
   },
   "dependencies": {
     "react": "19.0.0",
@@ -31,6 +39,7 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "19.0.0",
+    "rn-build-version": "^1.2.2",
     "typescript": "5.0.4"
   },
   "engines": {


### PR DESCRIPTION
## Summary:

Integrating `rn-build-version` into the React Native community template will streamline the management of Android build versions (`versionCode` and `versionName`) directly within the development workflow. This tool offers interactive prompts for version increments, automates backups, and updates changelogs, thereby enhancing the efficiency and reliability of the build process for developers.


## Changelog:

- **Added**: Inclusion of `rn-build-version` as a development dependency in the React Native community template to facilitate automated Android version management.

Pick one each for the category and type tags:

[ADDED] - Message


## Test Plan:

1. **Initialize a New React Native Project Using the Updated Template:**
   ```bash
   npx @react-native-community/cli@latest init TestApp
   ```


2. **Verify the Installation of `rn-build-version`:**
   - Navigate to the project directory:
     ```bash
     cd TestApp
     ```
   - Check `package.json` to confirm `rn-build-version` is listed under `devDependencies`.
   - Run `npm install` or `yarn install` to ensure all dependencies, including `rn-build-version`, are properly installed.

3. **Execute Build Commands Utilizing `rn-build-version`:**
   - Add the following scripts to the `package.json` under the `scripts` section: `(if you are not using this git repo)`
     ```json
     {
       "scripts": {
         "build:android:apk": "rn-build-version && cd android && ./gradlew clean assembleRelease",
         "build:android:aab": "rn-build-version && cd android && ./gradlew clean bundleRelease"
       }
     }
     ```
   - Run the production build command:
     ```bash
     npm run build:android:apk
     ```
   - During execution, confirm that `rn-build-version` prompts for version increment options and updates the `build.gradle` file accordingly.
   - Verify that the build artifacts (`.apk` or `.aab` files) are generated successfully in the `android/app/build/outputs` directory.

4. **Validate Changelog and Backup Creation:**
   - Ensure that a backup of the `build.gradle` file (`build.gradle.bak`) is created in the `android/app` directory.
   - Check for the existence and content of the `CHANGELOG.md` file to confirm that version details are accurately appended.

By following this test plan, we can ensure that integrating `rn-build-version` into the React Native community template enhances the Android build process, providing developers with a more streamlined and automated approach to version management.
