### PR TITLE
Bump Kotlin to 2.1.20

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 35
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.0.21"
+        kotlinVersion = "2.1.20"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary:

This bumps Kotlin in the same way as we're doing for facebook/react-native
