### PR TITLE
Bump React to 19.1

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.0.0",
+    "react": "19.1.0",
     "react-native": "1000.0.0"
   },
   "devDependencies": {
@@ -25,12 +25,12 @@
     "@react-native/metro-config": "0.80.0-main",
     "@react-native/typescript-config": "0.80.0-main",
     "@types/jest": "^29.5.13",
-    "@types/react": "^19.0.0",
-    "@types/react-test-renderer": "^19.0.0",
+    "@types/react": "^19.1.0",
+    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.0.0",
+    "react-test-renderer": "19.1.0",
     "typescript": "5.0.4"
   },
   "engines": {


### PR DESCRIPTION
## Summary:
We bumped React to 19.1 in the https://github.com/facebook/react-native repository.
We need to align the template or the e2e tests will fail.

## Changelog:
[General][Changed] - Bump React to 19.1

## Test Plan:
E2E tests in the https://github.com/facebook/react-native repo