### PR TITLE
Simplify tsconfig extends path

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@react-native/typescript-config/tsconfig.json"
+  "extends": "@react-native/typescript-config"
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

As titled. `@react-native/typescript-config` defines a `main` field.

At least in my local repo state today, this **fixed** `--jsx` complaints in my editor — but not sure this was the direct reason.

Changelog: [GENERAL][CHANGED] - Simplify `tsconfig.json` extends path

## Test Plan:

✅ `tsc`
