### PR TITLE
Reset Prettier brackets options to defaults

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -5,22 +5,15 @@
  * @format
  */
 
-import {NewAppScreen} from '@react-native/new-app-screen';
-import {
-  StatusBar,
-  StyleSheet,
-  useColorScheme,
-  View,
-} from 'react-native';
+import { NewAppScreen } from '@react-native/new-app-screen';
+import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
 
   return (
     <View style={styles.container}>
-      <StatusBar
-        barStyle={isDarkMode ? 'light-content' : 'dark-content'}
-      />
+      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
       <NewAppScreen templateFileName="App.tsx" />
     </View>
   );

--- a/template/_prettierrc.js
+++ b/template/_prettierrc.js
@@ -1,7 +1,5 @@
 module.exports = {
   arrowParens: 'avoid',
-  bracketSameLine: true,
-  bracketSpacing: false,
   singleQuote: true,
   trailingComma: 'all',
 };

--- a/template/index.js
+++ b/template/index.js
@@ -2,8 +2,8 @@
  * @format
  */
 
-import {AppRegistry} from 'react-native';
+import { AppRegistry } from 'react-native';
 import App from './App';
-import {name as appName} from './app.json';
+import { name as appName } from './app.json';
 
 AppRegistry.registerComponent(appName, () => App);

--- a/template/metro.config.js
+++ b/template/metro.config.js
@@ -1,4 +1,4 @@
-const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 
 /**
  * Metro configuration


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

> [!Note]
> Depends on https://github.com/react-native-community/template/pull/123.

We shouldn't push so many FB-specific code style decisions onto new React Native users. Resets these Prettier options to their defaults, aligning better with other open source templates.

```diff
- bracketSameLine: true,
- bracketSpacing: false,
```

Changelog: [GENERAL][CHANGED] - Simplify Prettier config

## Test Plan:

✅ See newly formatted files
