### PR TITLE
Bump TypeScript to latest, allow semver stable versions

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -32,7 +32,7 @@
     "jest": "^29.6.3",
     "prettier": "2.8.8",
     "react-test-renderer": "19.1.0",
-    "typescript": "5.0.4"
+    "typescript": "^5.8.3"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary

As titled — will include latest features and fixes (e.g. hardening of package.json `"exports"` support). I'm removing the exact version restriction also.

## Changelog:

[GENERAL][CHANGED] - Bump TypeScript to `^5.8.3`

## Test Plan

Validated locally.
