### PR TITLE
Bumped compileSdk, targetSdk

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
-        targetSdkVersion = 35
+        compileSdkVersion = 36
+        targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"
     }


### PR DESCRIPTION
## Summary:

This PR is analogous to https://github.com/facebook/react-native/pull/52355 and https://github.com/facebook/react-native/pull/52141 in the [React Native](https://github.com/facebook/react-native) repo. The testing process is mirroring the one happening in https://github.com/facebook/react-native/pull/52355

## Changelog:

We need to upgrade the targetSdk to 36, which requires ensuring compatibility with the latest Android APIs and addressing any deprecations or behavior changes introduced in this version.

## Test Plan:

- Verified that the app builds and runs successfully with targetSdkVersion 36.

- Ran the full suite of unit and instrumentation tests: all tests passed.

- Manually tested key user flows (login, navigation, data sync) on devices running Android 14 (API 34) and emulator with API 36

- Confirmed that there are no runtime crashes or warnings related to `targetSDK` upgrade.

Behavioral guide for migration: https://developer.android.com/about/versions/16/behavior-changes-16
