### PR TITLE
Update safe area handling for NewAppScreen (0.81)

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -7,14 +7,31 @@
 
 import { NewAppScreen } from '@react-native/new-app-screen';
 import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
+import {
+  SafeAreaProvider,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
 
   return (
-    <View style={styles.container}>
+    <SafeAreaProvider>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <NewAppScreen templateFileName="App.tsx" />
+      <AppContent />
+    </SafeAreaProvider>
+  );
+}
+
+function AppContent() {
+  const safeAreaInsets = useSafeAreaInsets();
+
+  return (
+    <View style={styles.container}>
+      <NewAppScreen
+        templateFileName="App.tsx"
+        safeAreaInsets={safeAreaInsets}
+      />
     </View>
   );
 }

--- a/template/package.json
+++ b/template/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "19.1.0",
     "react-native": "1000.0.0",
+    "react-native-safe-area-context": "^5.5.1",
     "@react-native/new-app-screen": "0.82.0-main"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Paired with https://github.com/facebook/react-native/pull/52507.

0.81 introduces user facing deprecation warnings for `SafeAreaView`. This PR updates the template with a dependency on [react-native-safe-area-context](https://www.npmjs.com/package/react-native-safe-area-context) and implements the optional `safeAreaInsets` prop on `NewAppScreen` (introduced to solve this in 0.81).

## Changelog:

[GENERAL][ADDED] - Update `App.tsx` with `SafeAreaProvider`, add dependency on `react-native-safe-area-context`

## Test Plan:

- With locally copied changes in `node_modules/@react-native/new-app-screen` to match https://github.com/facebook/react-native/pull/52507.

**Portrait**

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1ae9c81a-6a66-47e8-b39c-83617799ad56) | ![image](https://github.com/user-attachments/assets/5608f6e0-daa8-4bd6-bb2a-3d65ba9d3489) |
| | ✅ Renders correctly (Slight improvement: Bottom edge-to-edge behaviour now consistent for both platforms) | 

**Landscape** (note scrollbar within RHS safe area)

![image](https://github.com/user-attachments/assets/ce39e90e-4e92-4fe3-a7e2-7eecbc199312)


