### PR TITLE
[hotfix] Temporarily remove dep on react-native-safe-area-context

### DIFF
--- a/template/App.tsx
+++ b/template/App.tsx
@@ -7,31 +7,23 @@
 
 import { NewAppScreen } from '@react-native/new-app-screen';
 import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
-import {
-  SafeAreaProvider,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
 
   return (
-    <SafeAreaProvider>
+    <>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
       <AppContent />
-    </SafeAreaProvider>
+    </>
   );
 }
 
 function AppContent() {
-  const safeAreaInsets = useSafeAreaInsets();
-
+  // TODO(huntie): Restore safeAreaInsets assignment (see #153)
   return (
     <View style={styles.container}>
-      <NewAppScreen
-        templateFileName="App.tsx"
-        safeAreaInsets={safeAreaInsets}
-      />
+      <NewAppScreen templateFileName="App.tsx" />
     </View>
   );
 }

--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "react": "19.1.0",
     "react-native": "1000.0.0",
-    "react-native-safe-area-context": "^5.5.1",
     "@react-native/new-app-screen": "0.82.0-main"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Quick follow up to #151 to fix CI in the react-native repo.

This is a **temporary hotfix**, we plan to:

- Back on the react-native repo, undo the original, unintended breaking change that broke `react-native-safe-area-context` https://github.com/facebook/react-native/pull/51645.
  - https://github.com/facebook/react-native/pull/52528
- Release this in the next 0.81 RC.
- Restore the commented code in this PR — once we can use `react-native-safe-area-context` safely again.

## Changelog:
[INTERNAL]

## Test Plan:

> [!Warning]
> **Semi-broken state**: By removing the optional `safeAreaInsets` prop on `NewAppScreen`, the screen will render outside of the safe region. The above plan will restore correct behaviour in the next week.

<img width="1012" height="880" alt="image" src="https://github.com/user-attachments/assets/def0732d-9cf9-4f7e-81dc-1a1835a3cb54" />

<img width="848" height="427" alt="Screenshot 2025-07-10 at 12 16 54" src="https://github.com/user-attachments/assets/1ad289c7-d959-4db7-98a5-ba94f2fe3783" />

