### PR TITLE
Use TS types for test renderer from 19.1.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -28,7 +28,7 @@
     "@react-native/typescript-config": "0.82.0-main",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.1",
-    "@types/react-test-renderer": "^19.1.1",
+    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",


### PR DESCRIPTION
## Summary:

The React Native CI is failing because we haven't published the @types/react-test-renderer package on npm.

The types of react-test-renderer has not changed, so we can keep using the ones from 19.1.0

## Changelog:
[General][Changed] - reset types for react-test-renderer to 19.1.0 

## Test Plan:
RN CI