### PR TITLE
Add .gradle to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ yarn-error.log*
 # Files in template directory (when manually testing)
 /template/node_modules
 /template/yarn.lock
+
+# Gradle files that can be ignored
+.gradle/


### PR DESCRIPTION
## Summary:

This is just a small quality of life improvement as this folder keeps on showing up in the git status.
