### PR TITLE
chore: update Node.js engine requirement to >=20

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -36,6 +36,6 @@
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
## Summary:

React Native `0.81` now recommends Node.js `>=20` as the minimum supported version.  
This update changes the `engines.node` field in `package.json` from `>=18` to `>=20` to align with the recommended environment and ensure compatibility.

https://reactnative.dev/blog/2025/08/12/react-native-0.81#minimum-nodejs-bumped-to-20

## Changelog:

[GENERAL][CHANGED] - Updated Node.js engine requirement in `package.json` from `>=18` to `>=20` to match React Native 0.81 recommendation

## Test Plan: