### PR TITLE
fix: move to @testing-library/react-native

### DIFF
--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -2,12 +2,9 @@
  * @format
  */
 
-import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 import App from '../App';
 
 test('renders correctly', async () => {
-  await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />);
-  });
+  render(<App />);
 });

--- a/template/__tests__/App.test.tsx
+++ b/template/__tests__/App.test.tsx
@@ -5,6 +5,6 @@
 import { render } from '@testing-library/react-native';
 import App from '../App';
 
-test('renders correctly', async () => {
+test('renders correctly', () => {
   render(<App />);
 });

--- a/template/package.json
+++ b/template/package.json
@@ -26,13 +26,13 @@
     "@react-native/eslint-config": "0.82.0-main",
     "@react-native/metro-config": "0.82.0-main",
     "@react-native/typescript-config": "0.82.0-main",
+    "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.1",
     "@types/react-test-renderer": "^19.1.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.1.1",
     "typescript": "^5.8.3"
   },
   "engines": {

--- a/template/package.json
+++ b/template/package.json
@@ -29,7 +29,6 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.1.1",
-    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",


### PR DESCRIPTION
## Summary:

`react-test-renderer` is deprecated. 

https://react.dev/warnings/react-test-renderer

## Changelog:

[GENERAL] [ADDED|] - Move to @testing-library/react-native

## Test Plan:

Running tests should still pass.
