### PR TITLE
Add explicit use of `jest` types in `tsconfig.json`

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "@react-native/typescript-config",
+  "compilerOptions": {
+    "types": ["jest"],
+  },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["**/node_modules", "**/Pods"]
 }


### PR DESCRIPTION
## Summary:

See https://github.com/facebook/react-native/issues/53563 for more context.

TLDR; Since `jest` and `@types/jest` are dependencies of the app and not `react-native`, it makes sense to move this into the app template.
This also allow libraries (not necessarily using `jest`) to use `@react-native/typescript-config` without having to install `jest` or re-declare `types`.

## Changelog:

[GENERAL] [ADDED] - Add explicit use of `jest` types in `tsconfig.json`

## Test Plan:

1. Initialize the template `npx @react-native-community/cli@latest init TestApp`
2. Patch the `tsconfig.json`
3. Note how this doesn't affect the ability to use `describe` in source files.
