### PR TITLE
Bump React to 19.2.0 inside Community template

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.1.1",
+    "react": "19.2.0",
     "react-native": "1000.0.0",
     "@react-native/new-app-screen": "0.82.0-main",
     "react-native-safe-area-context": "^5.5.2"
@@ -27,12 +27,12 @@
     "@react-native/metro-config": "0.82.0-main",
     "@react-native/typescript-config": "0.82.0-main",
     "@types/jest": "^29.5.13",
-    "@types/react": "^19.1.1",
-    "@types/react-test-renderer": "^19.1.0",
+    "@types/react": "^19.2.0",
+    "@types/react-test-renderer": "^19.2.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.1.1",
+    "react-test-renderer": "19.2.0",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary:

Change in the template to bump React to 19.2.0. Needed for https://github.com/facebook/react-native/pull/54109

## Changelog:
[General][Changed] - Bump React to 19.2

## Test Plan:
E2E tests in RN are passing
