### PR TITLE
fix version for @types/react-test-renderer

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -28,7 +28,7 @@
     "@react-native/typescript-config": "0.82.0-main",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.2.0",
-    "@types/react-test-renderer": "^19.2.0",
+    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",


### PR DESCRIPTION
## Summary:
The @types/react-test-renderer does not have a version 19.2.0 on NPM. 
Types haven't changed for this module, so we can keep using 19.1.0 as version in the template.

This commit will fix the React Native CI