### PR TITLE
feat: support window resizing on iPad out-of-the-box

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -273,8 +273,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = HelloWorld;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -300,7 +302,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = HelloWorld;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -45,8 +45,13 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The motivation for this PR is for any app generated with the RN Community CLI using this template to include support for window resizing (by dragging the bottom-right corner) on iPads out-of-the-box. One example voice for such feature from the community can be found in https://github.com/facebook/react-native/issues/54105.

There are 2 changes required to bring support for window resizing on iPad:
- list iPad as a supported destination in `project.pbxproj` for the app not to run in compatibility mode
- list all 4 supported orientations [so as to enable](https://stackoverflow.com/a/32560406/4618440) resizing of the window to arbitrary size on iPad

## Changelog:

[IOS] [ADDED] - List iPhone and iPad as supported targets in project.pbxproj, support all 4 orientations on iPad in Info.plist to enable window resizing on iPad

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Test locally with `npx @react-native-community/cli@latest init AwesomeProject --template=file:/path/to/template`

Result before: unable to resize, as shown in https://github.com/facebook/react-native/issues/54105
Result after: ability to resize to minimum size (same as e.g. the system calendar app):

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/2b853980-0422-496c-8bb7-abe757ba2784" />