### PR TITLE
Use "nightly" version for all dependencies on main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,11 @@
 {
-  "name": "@react-native-community/template",
-  "version": "0.83.0-main",
-  "description": "The template used by `npx @react-native-community/cli init` to bootstrap a React Native application.",
-  "license": "MIT",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "scripts": {
-    "format": "prettier --write .",
     "test": "jest"
   },
-  "type": "commonjs",
-  "files": [
-    "template/*",
-    "template.config.js"
-  ],
   "dependencies": {},
   "devDependencies": {
     "jest": "^29.7.0",
-    "prettier": "^3.6.2",
     "semver": "^7.6.3"
-  },
-  "homepage": "https://github.com/react-native-community/template/tree/main",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/react-native-community/template.git"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "react": "19.2.0",
-    "react-native": "1000.0.0",
-    "@react-native/new-app-screen": "0.83.0-main",
+    "react-native": "nightly",
+    "@react-native/new-app-screen": "nightly",
     "react-native-safe-area-context": "^5.5.2"
   },
   "devDependencies": {
@@ -22,10 +22,10 @@
     "@react-native-community/cli": "20.0.0",
     "@react-native-community/cli-platform-android": "20.0.0",
     "@react-native-community/cli-platform-ios": "20.0.0",
-    "@react-native/babel-preset": "0.83.0-main",
-    "@react-native/eslint-config": "0.83.0-main",
-    "@react-native/metro-config": "0.83.0-main",
-    "@react-native/typescript-config": "0.83.0-main",
+    "@react-native/babel-preset": "nightly",
+    "@react-native/eslint-config": "nightly",
+    "@react-native/metro-config": "nightly",
+    "@react-native/typescript-config": "nightly",
     "@types/jest": "^29.5.13",
     "@types/react": "^19.2.0",
     "@types/react-test-renderer": "^19.1.0",


### PR DESCRIPTION
## Summary

**Motivation**: Reduce maintenance on the `main` branch of this repo.

- Remove `"0.x.0-main"` and `"1000.0.0"` placeholders for React Native package dependencies (which will not resolve without a `yarn link` setup). Instead, simplify by using `"nightly"` pointer — resolving to the latest nightly available on npm (effectively, each `-main` version).
- Simplify root `package.json` (drop version, drop npm-specific fields that are redundant for a project config).

Changelog: [Internal]

## Test Plan

```
yarn
yarn test
```
