### PR TITLE
Restore package metadata fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,23 @@
 {
-  "private": true,
+  "name": "@react-native-community/template",
+  "version": "0.83.0-main",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
+    "format": "prettier --write .",
     "test": "jest"
   },
+  "type": "commonjs",
+  "files": [
+    "template/*",
+    "template.config.js"
+  ],
   "dependencies": {},
   "devDependencies": {
     "jest": "^29.7.0",
+    "prettier": "^3.6.2",
     "semver": "^7.6.3"
   }
 }


### PR DESCRIPTION
## Summary

https://github.com/react-native-community/template/pull/184 was too aggressive, and broke React Native repo CI, which depends on pulling this repo's files and then running `npm pack` on the contents.

- Restore `name` and `version` fields in `package.json`.
- Also restore recently clobbered `prettier` dependency.

Changelog: [Internal]

## Test Plan

—
