### PR TITLE
Update debuggableVariants comments to include debugOptimized

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -19,7 +19,7 @@ react {
 
     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to
-    //   skip the bundling of the JS bundle and the assets. By default is just 'debug', 'debugOptimized'.
+    //   skip the bundling of the JS bundle and the assets. Default is "debug", "debugOptimized".
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
     // debuggableVariants = ["liteDebug", "liteDebugOptimized", "prodDebug", "prodDebugOptimized"]
 

--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -19,9 +19,9 @@ react {
 
     /* Variants */
     //   The list of variants to that are debuggable. For those we're going to
-    //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
+    //   skip the bundling of the JS bundle and the assets. By default is just 'debug', 'debugOptimized'.
     //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
-    // debuggableVariants = ["liteDebug", "prodDebug"]
+    // debuggableVariants = ["liteDebug", "liteDebugOptimized", "prodDebug", "prodDebugOptimized"]
 
     /* Bundling */
     //   A list containing the node command and its flags. Default is just 'node'.


### PR DESCRIPTION
## Summary:
Update the comments in build.gradle to also mention `debugOptimized` variant as debuggable by default and show an example usage with flavors