### PR TITLE
Update react and react-test-renderer versions to 19.2.3

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -10,7 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.2.0",
+    "react": "19.2.3",
     "react-native": "nightly",
     "@react-native/new-app-screen": "nightly",
     "react-native-safe-area-context": "^5.5.2"
@@ -32,7 +32,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.2.0",
+    "react-test-renderer": "19.2.3",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary:
In https://github.com/facebook/react-native/pull/54966, we are bumping React to version 19.2.3, to fix some vulnerabilities.

This PR contains the bump to the template to align to the React bump.

## Changelog:
[General][Changed] - Bumped React to 19.2.3

## Test Plan:
GHA