### PR TITLE
Remove stale 'com.facebook.react:hermes-android' dependency

### DIFF
--- a/template/android/app/build.gradle
+++ b/template/android/app/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
 
     if (hermesEnabled.toBoolean()) {
-        implementation("com.facebook.react:hermes-android")
+        implementation("com.facebook.hermes:hermes-android")
     } else {
         implementation jscFlavor
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR removes the manual dependency configuration for Hermes/JSC in `android/app/build.gradle`.

Since React Native 0.71, the React Native Gradle Plugin (`com.facebook.react`) automatically manages the JS engine dependencies based on the `hermesEnabled` property in `gradle.properties`. The manual `if (hermesEnabled.toBoolean())` block in the dependencies section is redundant and can be safely removed to simplify the build configuration.

Also, from React Native 0.83, hermes engine package name has been changed from `com.facebook.react:hermes-android` to `com.facebook.hermes/hermes-android`, making the manual if statement stale.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - Remove redundant Hermes/JSC dependency logic from build.gradle template

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Initialize a new React Native project with these changes applied to the Android template.
2. Ensure `hermesEnabled=true` is set in `android/gradle.properties`.
3. Run `./gradlew app:dependencies` inside the `android` folder.
4. Verify that `com.facebook.react:hermes-android` (or `com.facebook.hermes:hermes-android`) is still listed in the dependency tree, confirming the plugin injected it automatically.
5. Build and run the app on an Android emulator (`npm run android`).
6. Verify the app launches successfully and the Metro bundler confirms "Engine: Hermes".