### PR TITLE
chore(android): add dev and release scripts for React Native builds

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
+    "android:dev": "react-native run-android --active-arch-only",
+    "android:release": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",


### PR DESCRIPTION
Adding two scripts to run React Native on Android: one for release and one for development builds.
The development build targets only the current architecture, not all four.