### PR TITLE
Restore iPhone landscape orientations in iOS template

### DIFF
--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -45,6 +45,8 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>


### PR DESCRIPTION
See #206

Summary:

This restores support for iPhone landscape orientations in the iOS community template Info.plist.
As part of the work to support iPad window resizing (#183), the 0.84 template now only declares portrait for iPhone, which prevents rotation to landscape in newly created apps. This change reverts iPhone behaviour to the long-standing default, while keeping the iPad-specific orientation settings required for window resizing.

Changelog:

IOS FIXED - Restore iPhone landscape orientations in iOS community template Info.plist

Test Plan:
	•	Created a new app using the current community template (npx @react-native-community/cli init TestApp).
	•	Ran the app on an iPhone simulator.
	•	Before change: rotating the simulator does not rotate the app (portrait-only).
	•	After change: rotating the simulator correctly rotates the app to landscape left/right.
