### PR TITLE
Add /.bundle/ to gitignore and remove .bundle/config

### DIFF
--- a/template/_bundle/config
+++ b/template/_bundle/config
@@ -1,2 +1,0 @@
-BUNDLE_PATH: "vendor/bundle"
-BUNDLE_FORCE_RUBY_PLATFORM: 1

--- a/template/_gitignore
+++ b/template/_gitignore
@@ -56,9 +56,10 @@ yarn-error.log
 # Bundle artifact
 *.jsbundle
 
-# Ruby / CocoaPods
+# Ruby / Bundler / CocoaPods
 **/Pods/
 /vendor/bundle/
+/.bundle/
 
 # Temporary files created by Metro to check the health of the file watcher
 .metro-health-check*


### PR DESCRIPTION
## Summary:

- update `.gitignore` to include `/.bundle/`
- remove `/.bundle/config`

`bundle install --deployment`/`bundle config set deployment true` dirtifies the git state
causing the tracked local Bundler config yaml to drift overwriting it

```
bundle install --deployment
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment true`, and stop using this flag
```

from

https://github.com/react-native-community/template/blob/620f5a45615376dc894767bb2499a36564ddf9d7/template/_bundle/config#L1-L2

to

```yaml
---
BUNDLE_PATH: "vendor/bundle"
BUNDLE_FORCE_RUBY_PLATFORM: "1"
BUNDLE_DEPLOYMENT: "true"
```

in ephemeral CI environments and local testing (unintended afaik)

official convention (idiomatic way) is to gitignore `/.bundle/`
https://github.com/github/gitignore/blob/main/Ruby.gitignore#L42
and standard convention https://devcenter.heroku.com/articles/bundler-configuration

was likely an oversight to force it in VC earlier
- https://github.com/facebook/react-native/pull/32303 (circa RN 0.68)

to continue isolating the path from the global (polluted) OS folder
`bundle config set --local path 'vendor/bundle'` (run once per project)
`BUNDLE_PATH=vendor/bundle bundle install` (or in CI or a script)
`bundle install --path vendor/bundle` (deprecated)
and continue forcing ruby
`bundle config set --local force_ruby_platform true`
so if Gemfile.lock is regenerated PLATFORMS stick to ruby instead of changing per machine

both configs must now be explicitly set (opt-in instead of default)
so perhaps convening to standard gitignore is too intrusive

a good way to get there could be
phase 1 add `/.bundle/` to gitignore in template
phase 2a run both bundle config commands under-the-hood in RNCLI `init` or 2b add the current config file instead 2c warn the user to do one of these
phase 3 [dust settles] remove `.bundle/config` from the template, 

nit: adding to gitignore also prevents `release.yaml` potentially detecting/creating accidental commits via `/scripts` that get run before

https://github.com/react-native-community/template/blob/620f5a45615376dc894767bb2499a36564ddf9d7/.github/workflows/release.yaml#L51-L54

## Changelog:

[GENERAL] [FIXED] - Add /.bundle/ to .gitignore and remove local Bundler config

## Test Plan:

Before

`npx @react-native-community/cli@latest init AwesomeProject`
`.bundle/config` exists (tracked)

After

`npx @react-native-community/cli@latest init AwesomeProject`
`.bundle/config` # exists (untracked)
