### PR TITLE
Add @react-native/jest-preset to devDependencies (0.85-stable)

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -24,6 +24,7 @@
     "@react-native-community/cli-platform-ios": "20.1.0",
     "@react-native/babel-preset": "0.85.0-rc.1",
     "@react-native/eslint-config": "0.85.0-rc.1",
+    "@react-native/jest-preset": "0.85.0-rc.1",
     "@react-native/metro-config": "0.85.0-rc.1",
     "@react-native/typescript-config": "0.85.0-rc.1",
     "@types/jest": "^29.5.13",


### PR DESCRIPTION
## Summary:

Follows react-native-community/template#208 and facebook/react-native#55169, due in React Native 0.85.

Fix
- https://github.com/react-native-community/rn-diff-purge/issues/91

Resolve: https://github.com/react-native-community/template/issues/211

## Changelog:

[General][Fixed] - Add @react-native/jest-preset to package.json devDependencies

## Test Plan:

- leotm/react-native-template-new-architecture#1918
