### PR TITLE
[0.81] Fix version of react-test-renderer

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -32,7 +32,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "prettier": "2.8.8",
-    "react-test-renderer": "19.1.0",
+    "react-test-renderer": "19.1.4",
     "typescript": "^5.8.3"
   },
   "engines": {


### PR DESCRIPTION
## Summary:

The version react-test-renderer was no longer aligned with other react dependencies, causing errors e.g. with RNTL:

> Incorrect version of "react-test-renderer" detected. Expected "19.1.4", but found "19.1.0".

Originally `react-test-renderer` was (correctly) updated to `19.1.4` in #204, but then rolled back to 19.1.0 in https://github.com/react-native-community/template/commit/13b945d76425a431d1f08106e42e80304b59fcf4 right after. `@types/react-test-renderer@^19.1.4` does _not_ exist, and it is the only thing that should have been changed back to `^19.1.0` (leaving `react-test-renderer` aligned). It's done the same way on [0.82-stable](https://github.com/react-native-community/template/blob/0.82-stable/template/package.json), [0.83-stable](https://github.com/react-native-community/template/blob/0.83-stable/template/package.json), [0.84-stable](https://github.com/react-native-community/template/blob/0.84-stable/template/package.json).

This PR fixes it by aligning react-test-renderer with react (`19.1.4`).

## Changelog:

[GENERAL] [FIXED] - Fix version of react-test-renderer in 0.81.6 template

## Test Plan:

Install dependencies - verify everything resolves - verify error no longer shows up