### PR TITLE
Bump Kotlin to 2.2.0

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 36
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.1.20"
+        kotlinVersion = "2.2.0"
     }
     repositories {
         google()


### PR DESCRIPTION
## Summary

RN Bumped to Kotlin 2.2.0 on `main`. This aligns the template to the same version we use for RN.

## Test plan

- The nightly tests at https://github.com/react-native-community/nightly-tests/ should pass for `@react-native-async-storage/async-storage` after this fix