### PR TITLE
[0.87] Switch edgeToEdgeEnabled to true in template

### DIFF
--- a/template/android/gradle.properties
+++ b/template/android/gradle.properties
@@ -41,4 +41,4 @@ hermesEnabled=true
 # Use this property to enable edge-to-edge display support.
 # This allows your app to draw behind system bars for an immersive UI.
 # Note: Only works with ReactActivity and should not be used with custom Activity.
-edgeToEdgeEnabled=false
+edgeToEdgeEnabled=true


### PR DESCRIPTION
## Summary:

- Enable edge-to-edge display by default in the Android template.

## Changelog:

[ANDROID] [BREAKING] - Enable edge-to-edge display by default in the template.

## Test Plan:

- Create a new app from the template and verify the Android app renders behind system bars.