### PR TITLE
Remove sourceURL(for:) override — superseded by bundleURL() in new architecture

### DIFF
--- a/template/ios/HelloWorld/AppDelegate.swift
+++ b/template/ios/HelloWorld/AppDelegate.swift
@@ -34,9 +34,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 class ReactNativeDelegate: RCTDefaultReactNativeFactoryDelegate {
+#if !RCT_REMOVE_LEGACY_ARCH
+  // Required by `RCTBridgeDelegate` until the legacy architecture is fully
+  // removed. On newer React Native versions this symbol no longer exists, so
+  // the override is compiled out via SWIFT_ACTIVE_COMPILATION_CONDITIONS.
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     self.bundleURL()
   }
+#endif
 
   override func bundleURL() -> URL? {
 #if DEBUG


### PR DESCRIPTION
Remove sourceURL(for:) override — superseded by bundleURL() in new architecture

## Summary:

The sourceURLForBridge: method will be removed from RCTBridgeDelegate in https://github.com/facebook/react-native/pull/56831 due to the RCT_REMOVE_LEGACY_ARCH clean up. Then the override no longer overrides anything and fails Swift compilation. bundleURL() — already present below — is the replacement API on RCTReactNativeFactoryDelegate. This change depends on https://github.com/facebook/react-native/pull/56974

## Changelog:

[IOS][FIXED] Remove legacy architecture sourceURLForBridge from template/ios/HelloWorld/AppDelegate.swift

## Test Plan:

CI