### PR TITLE
Add `enableBabelRuntime` option to reduce a bundle size

### DIFF
--- a/template/babel.config.js
+++ b/template/babel.config.js
@@ -1,3 +1,11 @@
 module.exports = {
-  presets: ['module:@react-native/babel-preset'],
+  presets: [
+    [
+      'module:@react-native/babel-preset',
+      {
+        // Reduces bundle size: without `enableBabelRuntime`, Babel helper functions will be inlined multiple times across different files.
+        enableBabelRuntime: require('@babel/runtime/package.json').version,
+      },
+    ],
+  ],
 };


### PR DESCRIPTION

## Summary:

I described the issue here: https://x.com/tell_me_mur/status/2064328541861183526?s=20

shorty without babel runtime version specified, babel helpers will be inlined multiple times across different files instead on imported once 

## Changelog:

[GENERAL] [ADDED] - Add `enableBabelRuntime` option to reduce a bundle size

## Test Plan:

...
