### PR TITLE
Update tsconfig.json to remove jest types

### DIFF
--- a/template/tsconfig.json
+++ b/template/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "@react-native/typescript-config",
-  "compilerOptions": {
-    "types": ["jest"]
-  },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["**/node_modules", "**/Pods"]
 }


### PR DESCRIPTION

## Summary:

Removed jest types from compiler options as it already added in `@react-native/typescript-config`
see:  https://github.com/react/react-native/blob/1127e54d539a0bc998ecc43104c7573190a87de1/packages/typescript-config/tsconfig.json#L7

## Changelog:

[GENERAL] [CHANGED] - Remove jest types from tsconfig

## Test Plan:

...
