### PR TITLE
Bump compileSdk and buildTools to 37

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext {
-        buildToolsVersion = "36.0.0"
+        buildToolsVersion = "37.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 36
+        compileSdkVersion = 37
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.2.0"


### PR DESCRIPTION
## Summary:
Needed for https://github.com/react/react-native/pull/57284

## Changelog:
[ANDROID][CHANGED] - Updates the `compileSdk` to 37

