### PR TITLE
Enable npm trusted publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ on:
 jobs:
   publish_template:
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
       - name: Safeguard against branch name
         run: |
@@ -32,7 +33,7 @@ jobs:
       - name: Setup node.js
         uses: actions/setup-node@v4.0.0
         with:
-          node-version: 22
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
       - name: Determine new template version
         run: echo "VERSION=$(./scripts/bumpedTemplateVersion.sh ${{ inputs.version }})" >> $GITHUB_ENV
@@ -57,8 +58,6 @@ jobs:
           "${GIT[@]}" tag $VERSION
           "${GIT[@]}" push --tags
       - name: Publish on NPM (with tag if needed)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           args=(--dry-run)
           if [ "${{ inputs.dry_run }}" = "false" ]; then


### PR DESCRIPTION
 - Run `release.yml` with the `npm-publish` [environment](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments), set up to apply to protected branches only (`main` and `*-stable`)
 - Bump to running `npm publish` under latest Node LTS - `npm` CLI >= 11.5 (bundled with Node v24) is required for trusted publish.
 - Remove unused `NPM_TOKEN`
 
 Configured the corresponding settings on npm:

<img width="712" height="207" alt="image" src="https://github.com/user-attachments/assets/f3d39f82-dd1f-4e0e-9122-3a679148e3b9" />

Changelog: [Internal]

