### PR TITLE
fix(release): enable npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,9 +40,6 @@ jobs:
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
-      - name: Ensure npm supports trusted publishing
-        # Trusted publishing (OIDC) requires npm >= 11.5.1
-        run: npm install -g npm@latest
       - name: Determine new template version
         run: echo "VERSION=$(./scripts/bumpedTemplateVersion.sh ${{ inputs.version }})" >> $GITHUB_ENV
       - name: Update versions to input one

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,11 @@ jobs:
   publish_template:
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      # Required for npm trusted publishing (OIDC token exchange with the registry)
+      id-token: write
+      # Required so the bump commit & tag can be pushed back to the branch
+      contents: write
     steps:
       - name: Safeguard against branch name
         run: |
@@ -35,6 +40,9 @@ jobs:
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
+      - name: Ensure npm supports trusted publishing
+        # Trusted publishing (OIDC) requires npm >= 11.5.1
+        run: npm install -g npm@latest
       - name: Determine new template version
         run: echo "VERSION=$(./scripts/bumpedTemplateVersion.sh ${{ inputs.version }})" >> $GITHUB_ENV
       - name: Update versions to input one


### PR DESCRIPTION
## Summary

The Release workflow failed to publish the template with an npm `E404` (see [run 28942433881](https://github.com/react-native-community/template/actions/runs/28942433881)).

The 404 was misleading — it's what npm returns for an **unauthenticated** publish. The root cause: now that we use **trusted publishing**, the workflow needs to perform an OIDC token exchange, but it never did. The job was missing the `id-token: write` permission, so GitHub never minted an OIDC token and the publish went out with no credentials.

## Changes

- Add `permissions: id-token: write` (OIDC token exchange for trusted publishing) and `contents: write` (so the bump commit & tag can still be pushed — once a `permissions` block is declared, unlisted scopes default to `none`).
- Drop the now-obsolete `NODE_AUTH_TOKEN` env from the publish step.

(`node-version: lts/*` already bundles npm >= 11.5.1, which is required for trusted publishing, so no npm upgrade step is needed.)

## Follow-ups to verify (outside this repo)

- **npm trusted publisher config** must match: org `react-native-community`, repo `template`, workflow `release.yaml`, environment `npm-publish`.
- **GitHub environment `npm-publish`** deployment branch rules must permit `*-stable` branches.

Note: the bump commit/tag from the failed run already landed (`1e63335`), so a re-run will take the "No changes… Continue to retry" path straight to publishing.