### PR TITLE
fix(release): don't configure an npm token registry so OIDC trusted publishing can run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,12 @@ jobs:
         uses: actions/setup-node@v4.0.0
         with:
           node-version: 'lts/*'
-          registry-url: 'https://registry.npmjs.org'
+          # NOTE: intentionally NOT setting `registry-url` here.
+          # `registry-url` makes setup-node inject a job-wide NODE_AUTH_TOKEN and
+          # write an .npmrc with `_authToken=${NODE_AUTH_TOKEN}`. npm trusted
+          # publishing (OIDC) only activates when NO auth token is configured, so
+          # configuring a token would make `npm publish` skip OIDC entirely.
+          # The default registry is already https://registry.npmjs.org/.
       - name: Determine new template version
         run: echo "VERSION=$(./scripts/bumpedTemplateVersion.sh ${{ inputs.version }})" >> $GITHUB_ENV
       - name: Update versions to input one


### PR DESCRIPTION
## Summary

Follow-up to #236. The release still failed with `E404` ([run 28944013848](https://github.com/react-native-community/template/actions/runs/28944013848)) even though `id-token: write` is now declared.

Looking at the run log, **npm never attempted OIDC** — it went straight to a token-based `PUT` and got 404. The cause: `actions/setup-node` with `registry-url: 'https://registry.npmjs.org'` injects a **job-wide `NODE_AUTH_TOKEN`** env var (it shows up on every step in the log) and writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. npm's trusted publishing only activates when **no** auth token is configured, so npm used (empty) token auth and skipped OIDC.

## Change

Remove `registry-url` from the `setup-node` step. The default registry is already `https://registry.npmjs.org/`, and `publishConfig.access: public` is set in `package.json`, so no token-based `.npmrc` is needed.

## ⚠️ Also needs a settings change (not fixable in this file)

In the failed run, the `GITHUB_TOKEN Permissions` group listed only:

```
Contents: write
Metadata: read
```

`Id-token: write` was **requested but not granted**, which means OIDC token minting is disabled at the org/enterprise level. Even with this PR, trusted publishing can't work until an admin allows the `id-token` permission for this repo's Actions. Please also confirm the npm trusted-publisher config (org `react-native-community`, repo `template`, workflow `release.yaml`, environment `npm-publish`).