### PR TITLE
chore(release): add OIDC availability diagnostic

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,6 +45,16 @@ jobs:
           # publishing (OIDC) only activates when NO auth token is configured, so
           # configuring a token would make `npm publish` skip OIDC entirely.
           # The default registry is already https://registry.npmjs.org/.
+      - name: Debug OIDC availability
+        # GitHub only injects ACTIONS_ID_TOKEN_REQUEST_URL when `id-token: write`
+        # is actually granted. Prints presence only (never the value/token).
+        run: |
+          if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ]; then
+            echo "OIDC id-token IS available -> id-token: write is granted, OIDC can run."
+          else
+            echo "OIDC id-token is NOT available (ACTIONS_ID_TOKEN_REQUEST_URL is empty)."
+            echo "=> GitHub is not granting id-token: write for this run."
+          fi
       - name: Determine new template version
         run: echo "VERSION=$(./scripts/bumpedTemplateVersion.sh ${{ inputs.version }})" >> $GITHUB_ENV
       - name: Update versions to input one


### PR DESCRIPTION
Temporary diagnostic to disambiguate the `ENEEDAUTH` publish failure.

Adds a step that prints whether `ACTIONS_ID_TOKEN_REQUEST_URL` is present (presence only — never the value). GitHub only injects that env var when `id-token: write` is actually granted.

After merging, re-run the Release workflow and read the **Debug OIDC availability** step:
- "OIDC id-token IS available" → id-token is granted; the remaining issue is the npm trusted-publisher config on npmjs.com.
- "OIDC id-token is NOT available" → GitHub still isn't granting id-token; the restriction is at the enterprise level (org workflow permissions are already read/write).

Revert this once the release is green.