### PR TITLE
chore(release): dump npm debug log on publish failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,3 +93,10 @@ jobs:
           else
             npm publish "${args[@]}"
           fi
+      - name: Dump npm debug log on failure
+        if: failure()
+        # The npm debug log always contains full-detail output (including the
+        # OIDC trusted-publishing decision) regardless of console loglevel.
+        run: |
+          echo "=== npm debug log ==="
+          cat "$HOME"/.npm/_logs/*-debug-0.log 2>/dev/null || cat "$HOME"/.npm/_logs/*.log 2>/dev/null || echo "(no npm debug log found)"


### PR DESCRIPTION
Second diagnostic. The OIDC id-token IS available (previous diagnostic confirmed), npm is 11.16.0, and no token is configured — yet `npm publish` returns `ENEEDAUTH` with no OIDC-related output on the console.

npm always writes a full-detail debug log to `~/.npm/_logs/*-debug-0.log` regardless of console loglevel. This adds an `if: failure()` step that prints it, so we can see whether npm attempted the OIDC token exchange and what the registry replied (e.g. no trusted publisher configured / claim mismatch).

Revert once the release is green.