### PR TITLE
fix(release): enable npm trusted publishing (OIDC) on main to match stable branches

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,11 @@ jobs:
   publish_template:
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      # Required for npm trusted publishing (OIDC token exchange with the registry)
+      id-token: write
+      # Required so the bump commit & tag can be pushed back to the branch
+      contents: write
     steps:
       - name: Safeguard against branch name
         run: |
@@ -31,10 +36,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Setup node.js
-        uses: actions/setup-node@v4.0.0
+        # setup-node@v6 supports npm trusted publishing (OIDC): with `registry-url`
+        # set and no token provided, it configures the registry without writing a
+        # bogus NODE_AUTH_TOKEN placeholder, so `npm publish` performs the OIDC
+        # token exchange. Older versions (e.g. v4) wrote a placeholder token that
+        # made npm attempt token auth instead, failing with E404/ENEEDAUTH.
+        uses: actions/setup-node@v6
         with:
           node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
+          # Never cache dependencies in a publishing workflow: a poisoned cache
+          # could expose the short-lived OIDC token.
+          package-manager-cache: false
       - name: Determine new template version
         run: echo "VERSION=$(./scripts/bumpedTemplateVersion.sh ${{ inputs.version }})" >> $GITHUB_ENV
       - name: Update versions to input one


### PR DESCRIPTION
Ports the release workflow fixes proven out on `0.87-stable` so that future stable branches cut from `main` publish successfully via npm trusted publishing.

## What changed in `release.yaml`
- Add `permissions: id-token: write` (OIDC token exchange) + `contents: write` (push the bump commit/tag).
- Bump `actions/setup-node@v4.0.0` → `@v6`. v4 predates OIDC support and writes a placeholder `NODE_AUTH_TOKEN` that makes npm attempt token auth (→ `E404`/`ENEEDAUTH`) instead of OIDC.
- `package-manager-cache: false` (docs-recommended; avoids leaking the short-lived OIDC token via a poisoned cache).

`registry-url` and `environment: npm-publish` were already present. `package.json` already has the `repository` field (required for provenance) via #241.

## This is the complete diff vs 0.87-stable
`release.yaml` was the **only** difference between `main` and `0.87-stable` across all workflows + scripts; `nightly.yaml`, `scripts/`, and the `package.json` repository field were already identical.

## ⚠️ Follow-ups (not in this PR)
1. Every new stable branch still needs its **own npm trusted-publisher entry** matching `release.yaml` + environment `npm-publish` (npm allows only one trusted publisher per package, so it must be re-pointed/created per release line).
2. **`nightly.yaml` still publishes with `NODE_AUTH_TOKEN: secrets.NPM_TOKEN`** — see PR discussion; needs a decision since npm allows only one trusted publisher per package.