### PR TITLE
Bump targetSdkVersion to 37

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         buildToolsVersion = "37.0.0"
         minSdkVersion = 24
         compileSdkVersion = 37
-        targetSdkVersion = 36
+        targetSdkVersion = 37
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.2.0"
     }


### PR DESCRIPTION
## Summary:

We forgot to bump `targetSdkVersion` to 37 when bumping `compileSdkVersion` and `buildToolsVersion`

## Changelog:

[ANDROID] [CHANGED] - Bump targetSdkVersion to 37

## Test Plan:

N / A
