### PR TITLE
Set SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG in the Debug config

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
 				);
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 			};
 			name = Debug;
 		};


### PR DESCRIPTION
## Continuation in https://github.com/react/react-native/pull/57914

<del>## Summary:

<del>The app template's AppDelegate.swift gates the Metro bundle URL behind `#if DEBUG` (falling back to a non-existent main.jsbundle otherwise). In Swift, `#if DEBUG` is controlled by SWIFT_ACTIVE_COMPILATION_CONDITIONS, not by GCC_PREPROCESSOR_DEFINITIONS (which only affects C/ObjC/C++).

<del>Today this flag is not committed in project.pbxproj; it is injected at `pod install` time by react_native_post_install (react_native_pods.rb), which calls set_build_setting for SWIFT_ACTIVE_COMPILATION_CONDITIONS = ["$(inherited)", "DEBUG"] on the user project's Debug config.

<del>That means any setup that does not run CocoaPods (e.g. Swift Package Manager react-native experimental setup) never gets the flag, so `#if DEBUG` is false even in Debug builds. bundleURL() then returns nil and the app fails to launch with "No script url provided ... unsanitizedScriptURLString = (null)", even though Metro is running.

<del>Baking the setting into the template makes Debug builds work regardless of the dependency manager and matches the value CocoaPods already sets, so CocoaPods-based apps are unaffected.

<del>## Changelog:

<del>[IOS] [FIXED] - added missing SWIFT_ACTIVE_COMPILATION_CONDITIONS in debug config

<del>## Test Plan:

<del>building app without coocapods (react/react-native #57332)
</del>