### PR TITLE
refactor: remove fabricEnabled argument from `DefaultReactActivityDelegate()` call in MainActivity.kt since it is deprecated

### DIFF
--- a/template/android/app/src/main/java/com/helloworld/MainActivity.kt
+++ b/template/android/app/src/main/java/com/helloworld/MainActivity.kt
@@ -2,7 +2,6 @@ package com.helloworld
 
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
-import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
 class MainActivity : ReactActivity() {
@@ -14,9 +13,8 @@ class MainActivity : ReactActivity() {
   override fun getMainComponentName(): String = "HelloWorld"
 
   /**
-   * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
-   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   * Returns the instance of the [ReactActivityDelegate].
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate =
-      DefaultReactActivityDelegate(this, mainComponentName, fabricEnabled)
+      DefaultReactActivityDelegate(this, mainComponentName)
 }


### PR DESCRIPTION
## Summary:

`DefaultReactActivityDelegate` now only needs 2 parameters (`activity`, `mainComponentName`). 
The 3rd parameter has been marked as `@Suppress("UNUSED_PARAMETER")`, so the `createReactActivityDelegate()` 
override in `MainActivity.kt` is unnecessary boilerplate and can be safely removed from the template.

<img width="922" height="1070" alt="截屏2026-08-26 22 12 38" src="https://github.com/user-attachments/assets/a569526a-c448-43d7-ad19-0b6d61976eb9" />

## Changelog:

[ANDROID] [CHANGED] - Remove `fabricEnabled` argument from `DefaultReactActivityDelegate` constructor in `MainActivity.kt` since it is deprecated
